### PR TITLE
[DMS-31] motoko-san: enable viper tests

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -509,7 +509,7 @@ rec {
       run-deser  = test_subdir "run-deser"  [ deser ];
       perf       = perf_subdir "perf"       [ moc nixpkgs.drun ];
       bench      = perf_subdir "bench"      [ moc nixpkgs.drun ic-wasm ];
-      viper      = test_subdir "viper"      [ moc nixpkgs.which nixpkgs.openjdk nixpkgs.z3 ];
+      viper      = test_subdir "viper"      [ moc nixpkgs.which nixpkgs.openjdk nixpkgs.z3_4_12 ];
       inherit qc lsp unit candid profiling-graphs coverage;
     }) // { recurseForDerivations = true; };
 
@@ -818,7 +818,7 @@ EOF
           niv
           nix-update
           rlwrap # for `rlwrap moc`
-          openjdk z3 # for viper dev
+          openjdk z3_4_12 # for viper dev
           difftastic
         ] ++ lib.optional stdenv.isDarwin darwin.apple_sdk.frameworks.Security
       ));

--- a/default.nix
+++ b/default.nix
@@ -509,7 +509,7 @@ rec {
       run-deser  = test_subdir "run-deser"  [ deser ];
       perf       = perf_subdir "perf"       [ moc nixpkgs.drun ];
       bench      = perf_subdir "bench"      [ moc nixpkgs.drun ic-wasm ];
-      # viper      = test_subdir "viper"      [ moc nixpkgs.which nixpkgs.openjdk nixpkgs.z3 ];
+      viper      = test_subdir "viper"      [ moc nixpkgs.which nixpkgs.openjdk nixpkgs.z3 ];
       inherit qc lsp unit candid profiling-graphs coverage;
     }) // { recurseForDerivations = true; };
 


### PR DESCRIPTION
Tested locally, seems to work

```
$ nix-build --no-out-link
/nix/store/9x3vc2cv8pgjbxjm7bj785jiy2bm29r5-all-systems-go
/nix/store/hkr5phdyirqxvh5mbs28q1jsh8p188ag-base-doc
/nix/store/dvyb9zkkqxb8fw8cqa7z934cip7s88z1-base-src
/nix/store/iszz00c5jz6gpzbw689zw0c2l43hxva0-base-tests
/nix/store/masy6n95vhm63rxz123wsj4pin89m968-candid-tests
/nix/store/n68ly0c4p3wgsbk9rnfkrzxxzbs325jk-check-error-codes
/nix/store/vwarw7wa2nj7hg93wdb48hnjjrlrs4s9-check-formatting
/nix/store/saxijxm4jnhz6yvwaqkbwpsxnp47rfk1-check-generated
/nix/store/a404wn7q3y44nwyqxm6gg80j3f97617n-check-grammar
/nix/store/j3x3fmx0b959hl0rgkmqih109mzr4vgi-check-rts-formatting
/nix/store/1s6asj4pmq0ac8kab0lqlr8bwcmv9ry9-deser
/nix/store/c4lxl2q8svhnyvm77xxcw890fk5h8i40-didc
/nix/store/50cawwzwwp25zwc8kl45p7gfw2w57ahs-docs
/nix/store/syfkxkdx1pjd2h0krvmh9jv1z0ykyh7r-drun
/nix/store/5byid93lrx7vzy2zm9s8x0hp37p8yly9-FileCheck
/nix/store/f7b2yl226nbikiv6sbdhmaxg2452c8h5-git-minimal-2.42.0
/nix/store/dn79lzfcya3m1wf7sxqn9zqydjy06cyh-guid-examples-tc
/nix/store/21fmmsfzl2hng9p3fn9my9q13fn8ymas-ic-ref-run
/nix/store/6pbyzwdkm0wyscg3kpvmhwlf425ayls0-ic-wasm
/nix/store/5bxa2mb38qb6zdr992zif74wiq51i7rp-didc.js
/nix/store/fx8c59769m8i0wqk55ldpz9m80vhhqrk-moc.js
/nix/store/j0x2835bagd2aqhcrysgbg5p4vb6bzp8-moc_interpreter.js
/nix/store/vawdxf952bjbipknzqyn8wyb89dw43xy-lsp-int-0
/nix/store/alrn5kfzdpn9xyh4w3jz5wy2naw5rybb-mo-doc
/nix/store/jzxiydbpi35xp75xfz7l7qd5p73bmgj0-mo-ide
/nix/store/d4jizwff3g5ppl8bakbqph3kjiqhq7zj-mo-ld
/nix/store/7nxibc4s3byblb3292ik01il308yfz3m-moc
/nix/store/iaq4ap1a9bkpm6r2j5gwbsmgh7wi8f38-nix-update-1.0.0
/nix/store/x20jscfaw4ds6jdryc3li6jhhbk66bnm-qc-motoko-1
/nix/store/qss2gakqxny6yj76hwcnljpmqxih8sq7-report-site
/nix/store/28g624zni7g138mlbbdw6bng0qyhsxpz-moc-rts
/nix/store/mf8qaa50y9q0cm67g6dsxvbby7ypgpqg-samples
/nix/store/3lhj515v6j529hjxaggcvl6ix3ich8lr-motoko-shell
/nix/store/dhvxjpmr8sc39lp2pnfwxg2hbrl6hrlq-test-bench
/nix/store/9msba1f8049vakskgxi3z979yxy99z6n-test-candid
/nix/store/jz71pj7fqcb3f1zcd9ifk3zbfkkbg7xd-test-coverage
/nix/store/8kyjiq7wkpam2590avbf0pslcadi6cl6-test-drun
/nix/store/z99xaaxmfkvv1lkg8j27ff9lb793ksv2-test-drun-compacting-gc
/nix/store/iny46hbnxi6ir88xv19c3ry7vc5s0fk5-test-drun-dbg
/nix/store/k8hgg00q3sz07nb37g35sc4sfdgpfdzk-test-drun-generational-gc
/nix/store/7nf25kmh6misw4kch14qv8pwfa7nn5na-test-drun-incremental-gc
/nix/store/0p3jc2wj7x67n9d7v17nrc70zqcscycx-test-fail
/nix/store/xh08mnqwf9axmvxdxcgw1394iq65kb9g-test-idl
/nix/store/p1xzc35wdbycvn720nxj68ma3ri4p9x1-test-ld
/nix/store/s92dp2pf5insdy1xn6nykpp70bp32r61-test-lsp
/nix/store/yxbbgpxznq9lbid7gxfl7ajfqd4cy1lg-test-mo-idl
/nix/store/3csjfnmi77sm8ypd1yqq24v50kq0k5xx-test-perf
/nix/store/hs54wkxazp45irgj993r7g7jsxz9p06n-test-profiling-graphs
/nix/store/rd3iv78zyzsk133pbdx62i73g6ci9ylg-test-qc
/nix/store/7f4pwx9df5wqmlv5zg90m0y3jiri36r6-test-repl
/nix/store/qhydw08wyl3243kcd43dpxigf97d2nxd-test-run
/nix/store/jhy2m1mpipmr3f95qkpa4rr6zxhp2arp-test-run-dbg
/nix/store/3cbvr41rz2xdnbcpbwrbglq4pxyc57jp-test-run-deser
/nix/store/rcd7rs45s9195bg9sxg8fvcgfqij8lna-test-trap
/nix/store/vwkvjf3aa64zk63nb3wdzx4f5bc51c8h-test-unit
/nix/store/xg9x9w4i4252fn4s80c3bapbgi7i4mkm-test-viper
/nix/store/hxn39kq9jhgvydp1x1cfpwna40snd81s-viperserver.jar
/nix/store/vx5z7aglsmb8xn4x7h6nmhbnc1q6sdd5-wabt-1.0.34
/nix/store/5k94slxs3blljl6wa3bmn9aa0y0i46fs-ocaml4.12.1-wasm-1.1.1
/nix/store/wzlwr5qbwskdl47z3g16zr2422f3f8hs-wasmtime-15.0.1
```
