### PR TITLE
[DMS-11] Support options

### DIFF
--- a/src/viper/prelude.ml
+++ b/src/viper/prelude.ml
@@ -17,10 +17,19 @@ domain Tuple {
   function $prj_inv2(r: Ref): Int
   axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
 }
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
 /* Typed references */
 field $int: Int
 field $bool: Bool
 field $ref: Ref
 field $array: Array
 field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
 /* END PRELUDE */|prelude}

--- a/src/viper/pretty.ml
+++ b/src/viper/pretty.ml
@@ -123,6 +123,7 @@ and pp_typ ppf t =
   | RefT -> pr ppf "Ref"
   | ArrayT -> pr ppf "Array"
   | TupleT -> pr ppf "Tuple"
+  | OptionT t -> fprintf ppf "@[Option[%a]@]" pp_typ t
   | ConT(con, []) -> fprintf ppf "%s" con.it
   | ConT(con, ts) ->
       fprintf ppf "@[%s[%a]@]"

--- a/src/viper/syntax.ml
+++ b/src/viper/syntax.ml
@@ -101,5 +101,6 @@ and typ' =
   | RefT
   | ArrayT
   | TupleT
+  | OptionT of typ
   | ConT of id * typ list
 

--- a/test/viper/ok/array.silicon.ok
+++ b/test/viper/ok/array.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (array.vpr@37.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (array.vpr@46.1)

--- a/test/viper/ok/array.vpr.ok
+++ b/test/viper/ok/array.vpr.ok
@@ -17,12 +17,21 @@ domain Tuple {
   function $prj_inv2(r: Ref): Int
   axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
 }
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
 /* Typed references */
 field $int: Int
 field $bool: Bool
 field $ref: Ref
 field $array: Array
 field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
 /* END PRELUDE */
 
 define $Perm($Self) (((((true && (acc(($Self).immut_arr,write) && ($array_acc(

--- a/test/viper/ok/assertions.silicon.ok
+++ b/test/viper/ok/assertions.silicon.ok
@@ -1,2 +1,2 @@
-  [0] Postcondition of __init__ might not hold. Assertion $Self.u might not hold. (assertions.vpr@37.13--37.24)
-  [1] Assert might fail. Assertion $Self.u ==> $Self.v > 0 might not hold. (assertions.vpr@55.15--55.44)
+  [0] Postcondition of __init__ might not hold. Assertion $Self.u might not hold. (assertions.vpr@46.13--46.24)
+  [1] Assert might fail. Assertion $Self.u ==> $Self.v > 0 might not hold. (assertions.vpr@64.15--64.44)

--- a/test/viper/ok/assertions.vpr.ok
+++ b/test/viper/ok/assertions.vpr.ok
@@ -17,12 +17,21 @@ domain Tuple {
   function $prj_inv2(r: Ref): Int
   axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
 }
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
 /* Typed references */
 field $int: Int
 field $bool: Bool
 field $ref: Ref
 field $array: Array
 field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
 /* END PRELUDE */
 
 field $message_async: Int

--- a/test/viper/ok/async.silicon.ok
+++ b/test/viper/ok/async.silicon.ok
@@ -1,1 +1,1 @@
-  [0] Exhale might fail. Assertion $Self.$message_async <= 1 might not hold. (async.vpr@60.15--60.42)
+  [0] Exhale might fail. Assertion $Self.$message_async <= 1 might not hold. (async.vpr@69.15--69.42)

--- a/test/viper/ok/async.vpr.ok
+++ b/test/viper/ok/async.vpr.ok
@@ -17,12 +17,21 @@ domain Tuple {
   function $prj_inv2(r: Ref): Int
   axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
 }
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
 /* Typed references */
 field $int: Int
 field $bool: Bool
 field $ref: Ref
 field $array: Array
 field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
 /* END PRELUDE */
 
 field $message_async_4: Int

--- a/test/viper/ok/claim-broken.silicon.ok
+++ b/test/viper/ok/claim-broken.silicon.ok
@@ -1,1 +1,1 @@
-  [0] Exhale might fail. Assertion $Self.$message_async == 1 ==> $Self.claimed && $Self.count == 0 might not hold. (claim-broken.vpr@58.20--58.47)
+  [0] Exhale might fail. Assertion $Self.$message_async == 1 ==> $Self.claimed && $Self.count == 0 might not hold. (claim-broken.vpr@67.20--67.47)

--- a/test/viper/ok/claim-broken.vpr.ok
+++ b/test/viper/ok/claim-broken.vpr.ok
@@ -17,12 +17,21 @@ domain Tuple {
   function $prj_inv2(r: Ref): Int
   axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
 }
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
 /* Typed references */
 field $int: Int
 field $bool: Bool
 field $ref: Ref
 field $array: Array
 field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
 /* END PRELUDE */
 
 field $message_async: Int

--- a/test/viper/ok/claim-reward-naive.vpr.ok
+++ b/test/viper/ok/claim-reward-naive.vpr.ok
@@ -17,12 +17,21 @@ domain Tuple {
   function $prj_inv2(r: Ref): Int
   axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
 }
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
 /* Typed references */
 field $int: Int
 field $bool: Bool
 field $ref: Ref
 field $array: Array
 field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
 /* END PRELUDE */
 
 define $Perm($Self) (((true && acc(($Self).claimed,write)) && acc(($Self).count,write)))

--- a/test/viper/ok/claim-simple.silicon.ok
+++ b/test/viper/ok/claim-simple.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (claim-simple.vpr@29.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (claim-simple.vpr@38.1)

--- a/test/viper/ok/claim-simple.vpr.ok
+++ b/test/viper/ok/claim-simple.vpr.ok
@@ -17,12 +17,21 @@ domain Tuple {
   function $prj_inv2(r: Ref): Int
   axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
 }
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
 /* Typed references */
 field $int: Int
 field $bool: Bool
 field $ref: Ref
 field $array: Array
 field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
 /* END PRELUDE */
 
 define $Perm($Self) (((true && acc(($Self).claimed,write)) && acc(($Self).count,write)))

--- a/test/viper/ok/claim.vpr.ok
+++ b/test/viper/ok/claim.vpr.ok
@@ -17,12 +17,21 @@ domain Tuple {
   function $prj_inv2(r: Ref): Int
   axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
 }
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
 /* Typed references */
 field $int: Int
 field $bool: Bool
 field $ref: Ref
 field $array: Array
 field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
 /* END PRELUDE */
 
 field $message_async: Int

--- a/test/viper/ok/counter.silicon.ok
+++ b/test/viper/ok/counter.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (counter.vpr@29.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (counter.vpr@38.1)

--- a/test/viper/ok/counter.vpr.ok
+++ b/test/viper/ok/counter.vpr.ok
@@ -17,12 +17,21 @@ domain Tuple {
   function $prj_inv2(r: Ref): Int
   axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
 }
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
 /* Typed references */
 field $int: Int
 field $bool: Bool
 field $ref: Ref
 field $array: Array
 field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
 /* END PRELUDE */
 
 define $Perm($Self) ((true && acc(($Self).count,write)))

--- a/test/viper/ok/invariant.silicon.ok
+++ b/test/viper/ok/invariant.silicon.ok
@@ -1,1 +1,1 @@
-  [0] Postcondition of __init__ might not hold. Assertion $Self.count > 0 might not hold. (invariant.vpr@34.13--34.24)
+  [0] Postcondition of __init__ might not hold. Assertion $Self.count > 0 might not hold. (invariant.vpr@43.13--43.24)

--- a/test/viper/ok/invariant.vpr.ok
+++ b/test/viper/ok/invariant.vpr.ok
@@ -17,12 +17,21 @@ domain Tuple {
   function $prj_inv2(r: Ref): Int
   axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
 }
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
 /* Typed references */
 field $int: Int
 field $bool: Bool
 field $ref: Ref
 field $array: Array
 field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
 /* END PRELUDE */
 
 define $Perm($Self) (((true && acc(($Self).claimed,write)) && acc(($Self).count,write)))

--- a/test/viper/ok/loop-invariant.silicon.ok
+++ b/test/viper/ok/loop-invariant.silicon.ok
@@ -1,2 +1,2 @@
-Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (loop-invariant.vpr@28.1)
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (loop-invariant.vpr@29.1)
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (loop-invariant.vpr@37.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (loop-invariant.vpr@38.1)

--- a/test/viper/ok/loop-invariant.vpr.ok
+++ b/test/viper/ok/loop-invariant.vpr.ok
@@ -17,12 +17,21 @@ domain Tuple {
   function $prj_inv2(r: Ref): Int
   axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
 }
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
 /* Typed references */
 field $int: Int
 field $bool: Bool
 field $ref: Ref
 field $array: Array
 field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
 /* END PRELUDE */
 
 define $Perm($Self) (true)

--- a/test/viper/ok/method-call.silicon.ok
+++ b/test/viper/ok/method-call.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (method-call.vpr@29.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (method-call.vpr@38.1)

--- a/test/viper/ok/method-call.vpr.ok
+++ b/test/viper/ok/method-call.vpr.ok
@@ -17,12 +17,21 @@ domain Tuple {
   function $prj_inv2(r: Ref): Int
   axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
 }
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
 /* Typed references */
 field $int: Int
 field $bool: Bool
 field $ref: Ref
 field $array: Array
 field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
 /* END PRELUDE */
 
 define $Perm($Self) ((true && acc(($Self).boolFld,write)))

--- a/test/viper/ok/nats.silicon.ok
+++ b/test/viper/ok/nats.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (nats.vpr@29.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (nats.vpr@38.1)

--- a/test/viper/ok/nats.vpr.ok
+++ b/test/viper/ok/nats.vpr.ok
@@ -17,12 +17,21 @@ domain Tuple {
   function $prj_inv2(r: Ref): Int
   axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
 }
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
 /* Typed references */
 field $int: Int
 field $bool: Bool
 field $ref: Ref
 field $array: Array
 field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
 /* END PRELUDE */
 
 define $Perm($Self) ((true && acc(($Self).x,write)))

--- a/test/viper/ok/option.silicon.ok
+++ b/test/viper/ok/option.silicon.ok
@@ -1,0 +1,1 @@
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (option.vpr@38.1)

--- a/test/viper/ok/option.tc.ok
+++ b/test/viper/ok/option.tc.ok
@@ -1,0 +1,7 @@
+option.mo:3.9-3.13: warning [M0194], unused identifier fld1 (delete or rename to wildcard `_` or `_fld1`)
+option.mo:8.13-8.15: warning [M0194], unused identifier t2 (delete or rename to wildcard `_` or `_t2`)
+option.mo:9.13-9.15: warning [M0194], unused identifier t3 (delete or rename to wildcard `_` or `_t3`)
+option.mo:10.13-10.15: warning [M0194], unused identifier t4 (delete or rename to wildcard `_` or `_t4`)
+option.mo:32.19-32.29: warning [M0194], unused identifier passOption (delete or rename to wildcard `_` or `_passOption`)
+option.mo:33.13-33.15: warning [M0194], unused identifier a2 (delete or rename to wildcard `_` or `_a2`)
+option.mo:36.18-36.27: warning [M0194], unused identifier callTuple (delete or rename to wildcard `_` or `_callTuple`)

--- a/test/viper/ok/option.vpr.ok
+++ b/test/viper/ok/option.vpr.ok
@@ -1,0 +1,133 @@
+/* BEGIN PRELUDE */
+/* Array encoding */
+domain Array {
+  function $loc(a: Array, i: Int): Ref
+  function $size(a: Array): Int
+  function $loc_inv1(r: Ref): Array
+  function $loc_inv2(r: Ref): Int
+  axiom $all_diff_array { forall a: Array, i: Int :: {$loc(a, i)} $loc_inv1($loc(a, i)) == a && $loc_inv2($loc(a, i)) == i }
+  axiom $size_nonneg { forall a: Array :: $size(a) >= 0 }
+}
+define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
+define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+/* Tuple encoding */
+domain Tuple {
+  function $prj(a: Tuple, i: Int): Ref
+  function $prj_inv1(r: Ref): Tuple
+  function $prj_inv2(r: Ref): Int
+  axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
+}
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
+/* Typed references */
+field $int: Int
+field $bool: Bool
+field $ref: Ref
+field $array: Array
+field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
+/* END PRELUDE */
+
+define $Perm($Self) (((true && acc(($Self).fld1,write)) && acc(($Self).fld2,write)))
+define $Inv($Self) (true)
+method __init__($Self: Ref)
+    
+    requires $Perm($Self)
+    ensures $Perm($Self)
+    ensures $Inv($Self)
+    { 
+      ($Self).fld1 := None();
+      ($Self).fld2 := Some(true); 
+    }
+field fld1: Option[Int]
+field fld2: Option[Bool]
+method localOption($Self: Ref)
+    
+    requires $Perm($Self)
+    requires $Inv($Self)
+    ensures $Perm($Self)
+    ensures $Inv($Self)
+    { var t1: Option[Int]
+      var t2: Option[Int]
+      var t3: Option[Int]
+      var t4: Option[Int]
+      var a2: Int
+      t1 := None();
+      t2 := Some(42);
+      t3 := None();
+      t4 := Some(32);
+      a2 := 0;
+      if ((t1).isNone)
+         { 
+           a2 := 0; 
+         }else
+         { 
+           if ((t1).isSome)
+              { var x: Int
+                x := (t1).some$0;
+                a2 := x; 
+              }; 
+         };
+      label $Ret; 
+    }
+method getOption($Self: Ref)
+     returns ($Res: Option[Bool])
+    requires $Perm($Self)
+    ensures $Perm($Self)
+    { 
+      $Res := Some(false);
+      goto $Ret;
+      label $Ret; 
+    }
+method takeOption($Self: Ref, a: Option[Int])
+     returns ($Res: Int)
+    requires $Perm($Self)
+    ensures $Perm($Self)
+    { 
+      if ((a).isNone)
+         { 
+           $Res := 0;
+           goto $Ret; 
+         }else
+         { 
+           if ((a).isSome)
+              { var x: Int
+                x := (a).some$0;
+                $Res := x;
+                goto $Ret; 
+              }; 
+         };
+      label $Ret; 
+    }
+method passOption($Self: Ref)
+    
+    requires $Perm($Self)
+    ensures $Perm($Self)
+    { var a2: Int
+      a2 := takeOption($Self, None());
+      label $Ret; 
+    }
+method callTuple($Self: Ref)
+    
+    requires $Perm($Self)
+    ensures $Perm($Self)
+    { var x: Option[Bool]
+      x := getOption($Self);
+      label $Ret; 
+    }
+method changeField($Self: Ref)
+    
+    requires $Perm($Self)
+    requires $Inv($Self)
+    ensures $Perm($Self)
+    ensures $Inv($Self)
+    { 
+      ($Self).fld2 := None();
+      label $Ret; 
+    }

--- a/test/viper/ok/option.vpr.stderr.ok
+++ b/test/viper/ok/option.vpr.stderr.ok
@@ -1,0 +1,7 @@
+option.mo:3.9-3.13: warning [M0194], unused identifier fld1 (delete or rename to wildcard `_` or `_fld1`)
+option.mo:8.13-8.15: warning [M0194], unused identifier t2 (delete or rename to wildcard `_` or `_t2`)
+option.mo:9.13-9.15: warning [M0194], unused identifier t3 (delete or rename to wildcard `_` or `_t3`)
+option.mo:10.13-10.15: warning [M0194], unused identifier t4 (delete or rename to wildcard `_` or `_t4`)
+option.mo:32.19-32.29: warning [M0194], unused identifier passOption (delete or rename to wildcard `_` or `_passOption`)
+option.mo:33.13-33.15: warning [M0194], unused identifier a2 (delete or rename to wildcard `_` or `_a2`)
+option.mo:36.18-36.27: warning [M0194], unused identifier callTuple (delete or rename to wildcard `_` or `_callTuple`)

--- a/test/viper/ok/polymono.silicon.ok
+++ b/test/viper/ok/polymono.silicon.ok
@@ -1,2 +1,2 @@
-Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (polymono.vpr@28.1)
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (polymono.vpr@29.1)
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (polymono.vpr@37.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (polymono.vpr@38.1)

--- a/test/viper/ok/polymono.vpr.ok
+++ b/test/viper/ok/polymono.vpr.ok
@@ -17,12 +17,21 @@ domain Tuple {
   function $prj_inv2(r: Ref): Int
   axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
 }
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
 /* Typed references */
 field $int: Int
 field $bool: Bool
 field $ref: Ref
 field $array: Array
 field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
 /* END PRELUDE */
 
 define $Perm($Self) (true)

--- a/test/viper/ok/private.vpr.ok
+++ b/test/viper/ok/private.vpr.ok
@@ -17,12 +17,21 @@ domain Tuple {
   function $prj_inv2(r: Ref): Int
   axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
 }
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
 /* Typed references */
 field $int: Int
 field $bool: Bool
 field $ref: Ref
 field $array: Array
 field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
 /* END PRELUDE */
 
 define $Perm($Self) (((true && acc(($Self).claimed,write)) && acc(($Self).count,write)))

--- a/test/viper/ok/reverse.silicon.ok
+++ b/test/viper/ok/reverse.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (reverse.vpr@32.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (reverse.vpr@41.1)

--- a/test/viper/ok/reverse.vpr.ok
+++ b/test/viper/ok/reverse.vpr.ok
@@ -17,12 +17,21 @@ domain Tuple {
   function $prj_inv2(r: Ref): Int
   axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
 }
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
 /* Typed references */
 field $int: Int
 field $bool: Bool
 field $ref: Ref
 field $array: Array
 field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
 /* END PRELUDE */
 
 define $Perm($Self) ((true && (acc(($Self).xarray,write) && ($array_acc(

--- a/test/viper/ok/simple-funs.silicon.ok
+++ b/test/viper/ok/simple-funs.silicon.ok
@@ -1,2 +1,2 @@
-Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (simple-funs.vpr@28.1)
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (simple-funs.vpr@29.1)
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (simple-funs.vpr@37.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (simple-funs.vpr@38.1)

--- a/test/viper/ok/simple-funs.vpr.ok
+++ b/test/viper/ok/simple-funs.vpr.ok
@@ -17,12 +17,21 @@ domain Tuple {
   function $prj_inv2(r: Ref): Int
   axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
 }
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
 /* Typed references */
 field $int: Int
 field $bool: Bool
 field $ref: Ref
 field $array: Array
 field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
 /* END PRELUDE */
 
 define $Perm($Self) (true)

--- a/test/viper/ok/tuple.silicon.ok
+++ b/test/viper/ok/tuple.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (tuple.vpr@33.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (tuple.vpr@42.1)

--- a/test/viper/ok/tuple.tc.ok
+++ b/test/viper/ok/tuple.tc.ok
@@ -2,4 +2,4 @@ tuple.mo:32.18-32.27: warning [M0194], unused identifier passTuple (delete or re
 tuple.mo:35.13-35.14: warning [M0194], unused identifier r (delete or rename to wildcard `_` or `_r`)
 tuple.mo:39.13-39.15: warning [M0194], unused identifier r2 (delete or rename to wildcard `_` or `_r2`)
 tuple.mo:42.18-42.27: warning [M0194], unused identifier callTuple (delete or rename to wildcard `_` or `_callTuple`)
-tuple.mo:49.13-49.14: warning [M0194], unused identifier x (delete or rename to wildcard `_` or `_x`)
+tuple.mo:50.13-50.14: warning [M0194], unused identifier x (delete or rename to wildcard `_` or `_x`)

--- a/test/viper/ok/tuple.vpr.ok
+++ b/test/viper/ok/tuple.vpr.ok
@@ -175,8 +175,13 @@ method callTuple($Self: Ref)
     requires $Perm($Self)
     ensures $Perm($Self)
     { var t: Tuple
+      var a: Int
+      var b: Bool
       t := getTuple($Self);
       assume ((($prj(t, 0)).$int == 42) && (($prj(t, 1)).$bool == false));
+      a := ($prj(t, 0)).$int;
+      b := ($prj(t, 1)).$bool;
+      assume ((a == 42) && (b == false));
       label $Ret; 
     }
 method changeField($Self: Ref)

--- a/test/viper/ok/tuple.vpr.ok
+++ b/test/viper/ok/tuple.vpr.ok
@@ -17,12 +17,21 @@ domain Tuple {
   function $prj_inv2(r: Ref): Int
   axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
 }
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
 /* Typed references */
 field $int: Int
 field $bool: Bool
 field $ref: Ref
 field $array: Array
 field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
 /* END PRELUDE */
 
 define $Perm($Self) (((true && (acc(($Self).fld1,write) && (acc(($prj(

--- a/test/viper/ok/tuple.vpr.stderr.ok
+++ b/test/viper/ok/tuple.vpr.stderr.ok
@@ -2,4 +2,4 @@ tuple.mo:32.18-32.27: warning [M0194], unused identifier passTuple (delete or re
 tuple.mo:35.13-35.14: warning [M0194], unused identifier r (delete or rename to wildcard `_` or `_r`)
 tuple.mo:39.13-39.15: warning [M0194], unused identifier r2 (delete or rename to wildcard `_` or `_r2`)
 tuple.mo:42.18-42.27: warning [M0194], unused identifier callTuple (delete or rename to wildcard `_` or `_callTuple`)
-tuple.mo:49.13-49.14: warning [M0194], unused identifier x (delete or rename to wildcard `_` or `_x`)
+tuple.mo:50.13-50.14: warning [M0194], unused identifier x (delete or rename to wildcard `_` or `_x`)

--- a/test/viper/ok/variants.silicon.ok
+++ b/test/viper/ok/variants.silicon.ok
@@ -1,2 +1,2 @@
-Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (variants.vpr@28.1)
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (variants.vpr@29.1)
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (variants.vpr@37.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (variants.vpr@38.1)

--- a/test/viper/ok/variants.vpr.ok
+++ b/test/viper/ok/variants.vpr.ok
@@ -17,12 +17,21 @@ domain Tuple {
   function $prj_inv2(r: Ref): Int
   axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
 }
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
 /* Typed references */
 field $int: Int
 field $bool: Bool
 field $ref: Ref
 field $array: Array
 field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
 /* END PRELUDE */
 
 define $Perm($Self) (true)

--- a/test/viper/option.mo
+++ b/test/viper/option.mo
@@ -1,0 +1,43 @@
+actor Option {
+
+    let fld1: ?Int = null;
+    var fld2: ?Bool = ?true;
+
+    public func localOption(): async () {
+        let t1 = null : ?Int;
+        let t2 = ?42 : ?Int;
+        var t3 = null : ?Int;
+        var t4 = ?32 : ?Int;
+
+        // let a1 = switch t1 { case null 0; case (?x) x};
+        // let a2 = switch t1 { case null null; case (?x) (?(x + 1))};
+        var a2 : Int = 0;
+        switch t1 {
+            case null a2 := 0;
+            case (?x) a2 := x;
+        }
+    };
+
+    private func getOption(): ?Bool {
+        return ?false;
+    };
+
+    private func takeOption(a: ?Int): Int {
+        switch a {
+            case null { return 0 };
+            case (?x) { return x };
+        }
+    };
+
+     private func passOption(): () {
+        let a2 = takeOption(null);
+    };
+
+    private func callTuple(): () {
+        let x = getOption();
+    };
+
+    public func changeField(): async () {
+        fld2 := null;
+    }
+}

--- a/test/viper/tuple.mo
+++ b/test/viper/tuple.mo
@@ -41,8 +41,9 @@ actor Tuple {
 
     private func callTuple(): () {
         let t = getTuple();
-        assert t.0 == 42 and t.1 == false
-        // let (a, b) = getTuple();
+        assert t.0 == 42 and t.1 == false;
+        let (a, b) = t;
+        assert a == 42 and b == false;
     };
 
     public func changeField(): async () {


### PR DESCRIPTION
Limitations:
+ Switch is supported only as a statement, so:
  ```
    // instead of
    // let a1 = switch t1 { case null 0; case (?x) x};
    // we have to write: 
    var a1 : Int = 0;
    switch t1 {
        case null a1 := 0;
        case (?x) a1 := x;
    }
  ```
+ Optional array or array of options
  ```
  var opt_arr: ?[Int] = ?[1, 2]; 
  ```
  problem: `assign_stmts` fallback on `OptE` to `exp` which cannot handle array since it have to return stmts
  ```
  var arr_opt: [?Int] = [null, ?2];
  ```
  problem: `assign_stmts` calls `alloc_array` which handle only expressions

Both problems is not related to option, but rather general problem of translating statements and expressions which probably can be solved by A-normal form translation.