### PR TITLE
[DMS-39] Support labels, breaks, and continues

### DIFF
--- a/src/viper/common.ml
+++ b/src/viper/common.ml
@@ -3,3 +3,8 @@ exception Unsupported of Source.region * string
 
 let unsupported at sexp =
   raise (Unsupported (at, (Wasm.Sexpr.to_string 80 sexp)))
+
+let rec map_last ~f = function
+  | [] -> []
+  | [ x ] -> [ f x ]
+  | x :: xs -> x :: map_last ~f xs

--- a/test/viper/label-break-continue.mo
+++ b/test/viper/label-break-continue.mo
@@ -1,0 +1,70 @@
+// @verify
+
+actor LabelBreakContinue {
+  func label_expressions() {
+    let simple_label = label simple : Int break simple(42);
+    assert:system simple_label == 42;
+
+    let implicit_leave = label implicit : Int 42;
+    assert:system implicit_leave == 42;
+
+    let block_label_early_expr = label block : (Int, Int) {
+      if (true) break block(42, 42);
+      (24, 24)
+    };
+    assert:system block_label_early_expr.0 == 42 and block_label_early_expr.1 == 42;
+
+    let block_label_expr = label block : (Int, Int) {
+      if (false) break block(42, 42);
+      (24, 24)
+    };
+    assert:system block_label_expr.0 == 24 and block_label_expr.1 == 24;
+
+    var v = 0;
+    let mut_label = label mutability : () {
+      if (true) break mutability(v := 42);
+      v := 100;
+    };
+    assert:system v == 42;
+
+    v := 0;
+    let mut_label_2 = label mutability : () {
+      if (false) break mutability(v := 42);
+      v := 100;
+    };
+    assert:system v == 100;
+  };
+
+  func loops() {
+    var i = 0;
+    label while_loop while (i < 5) {
+      assert:loop:invariant (i < 3);
+      i := i + 1;
+      if (i == 3) break while_loop;
+      continue while_loop;
+      i := 100
+    };
+
+    // TODO: uncomment this when for loops are supported.
+    /* let range = [0, 1, 2, 3, 4, 5];
+
+    i := 0;
+    label for_loop for(j in range.vals()) {
+      assert:loop:invariant (j == i);
+      assert:loop:invariant (j < 3);
+      i := i + 1;
+      if (j == 3) break for_loop;
+      continue for_loop;
+      i := 100;
+    }; */
+
+    // TODO: uncomment this when loops are supported.
+    /* i := 0;
+    label regular_loop loop {
+      assert:loop:invariant (i < 5);
+      i := i + 1;
+      if (i == 4) break regular_loop;
+      i := 100;
+    }; */
+  }
+}

--- a/test/viper/ok/label-break-continue.silicon.ok
+++ b/test/viper/ok/label-break-continue.silicon.ok
@@ -1,0 +1,2 @@
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (label-break-continue.vpr@38.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (label-break-continue.vpr@39.1)

--- a/test/viper/ok/label-break-continue.tc.ok
+++ b/test/viper/ok/label-break-continue.tc.ok
@@ -1,0 +1,4 @@
+label-break-continue.mo:4.8-4.25: warning [M0194], unused identifier label_expressions (delete or rename to wildcard `_` or `_label_expressions`)
+label-break-continue.mo:24.9-24.18: warning [M0194], unused identifier mut_label (delete or rename to wildcard `_` or `_mut_label`)
+label-break-continue.mo:31.9-31.20: warning [M0194], unused identifier mut_label_2 (delete or rename to wildcard `_` or `_mut_label_2`)
+label-break-continue.mo:38.8-38.13: warning [M0194], unused identifier loops (delete or rename to wildcard `_` or `_loops`)

--- a/test/viper/ok/label-break-continue.vpr.ok
+++ b/test/viper/ok/label-break-continue.vpr.ok
@@ -1,0 +1,163 @@
+/* BEGIN PRELUDE */
+/* Array encoding */
+domain Array {
+  function $loc(a: Array, i: Int): Ref
+  function $size(a: Array): Int
+  function $loc_inv1(r: Ref): Array
+  function $loc_inv2(r: Ref): Int
+  axiom $all_diff_array { forall a: Array, i: Int :: {$loc(a, i)} $loc_inv1($loc(a, i)) == a && $loc_inv2($loc(a, i)) == i }
+  axiom $size_nonneg { forall a: Array :: $size(a) >= 0 }
+}
+define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
+define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
+/* Tuple encoding */
+domain Tuple {
+  function $prj(a: Tuple, i: Int): Ref
+  function $prj_inv1(r: Ref): Tuple
+  function $prj_inv2(r: Ref): Int
+  axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
+}
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
+/* Typed references */
+field $int: Int
+field $bool: Bool
+field $ref: Ref
+field $array: Array
+field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
+/* END PRELUDE */
+
+define $Perm($Self) (true)
+define $Inv($Self) (true)
+method __init__($Self: Ref)
+    
+    requires $Perm($Self)
+    ensures $Perm($Self)
+    ensures $Inv($Self)
+    { 
+       
+    }
+method label_expressions($Self: Ref)
+    
+    requires $Perm($Self)
+    ensures $Perm($Self)
+    { var simple_label: Int
+      var implicit_leave: Int
+      var block_label_early_expr: Tuple
+      var $t_block_label_early_expr_2: Tuple
+      var block_label_expr: Tuple
+      var $t_block_label_expr_2: Tuple
+      var v: Int
+      var mut_label: Tuple
+      var mut_label_2: Tuple
+      simple_label := 42;
+      goto $lbl$simple;
+      label $lbl$simple;
+      assert (simple_label == 42);
+      implicit_leave := 42;
+      goto $lbl$implicit;
+      label $lbl$implicit;
+      assert (implicit_leave == 42);
+      if (true)
+         { var $t_block_label_early_expr: Tuple
+           inhale (acc(($prj($t_block_label_early_expr, 0)).$int,write) && 
+              acc(($prj($t_block_label_early_expr, 1)).$int,write));
+           ($prj($t_block_label_early_expr, 0)).$int := 42;
+           ($prj($t_block_label_early_expr, 1)).$int := 42;
+           exhale acc(($prj($t_block_label_early_expr, 0)).$int,wildcard);
+           inhale acc(($prj($t_block_label_early_expr, 0)).$int,wildcard);
+           exhale acc(($prj($t_block_label_early_expr, 1)).$int,wildcard);
+           inhale acc(($prj($t_block_label_early_expr, 1)).$int,wildcard);
+           block_label_early_expr := $t_block_label_early_expr;
+           goto $lbl$block; 
+         };
+      inhale (acc(($prj($t_block_label_early_expr_2, 0)).$int,write) && 
+         acc(($prj($t_block_label_early_expr_2, 1)).$int,write));
+      ($prj($t_block_label_early_expr_2, 0)).$int := 24;
+      ($prj($t_block_label_early_expr_2, 1)).$int := 24;
+      exhale acc(($prj($t_block_label_early_expr_2, 0)).$int,wildcard);
+      inhale acc(($prj($t_block_label_early_expr_2, 0)).$int,wildcard);
+      exhale acc(($prj($t_block_label_early_expr_2, 1)).$int,wildcard);
+      inhale acc(($prj($t_block_label_early_expr_2, 1)).$int,wildcard);
+      block_label_early_expr := $t_block_label_early_expr_2;
+      goto $lbl$block;
+      label $lbl$block;
+      assert ((($prj(block_label_early_expr, 0)).$int == 42) && (($prj(block_label_early_expr,
+                                                                   1)).$int == 42));
+      if (false)
+         { var $t_block_label_expr: Tuple
+           inhale (acc(($prj($t_block_label_expr, 0)).$int,write) && 
+              acc(($prj($t_block_label_expr, 1)).$int,write));
+           ($prj($t_block_label_expr, 0)).$int := 42;
+           ($prj($t_block_label_expr, 1)).$int := 42;
+           exhale acc(($prj($t_block_label_expr, 0)).$int,wildcard);
+           inhale acc(($prj($t_block_label_expr, 0)).$int,wildcard);
+           exhale acc(($prj($t_block_label_expr, 1)).$int,wildcard);
+           inhale acc(($prj($t_block_label_expr, 1)).$int,wildcard);
+           block_label_expr := $t_block_label_expr;
+           goto $lbl$block_2; 
+         };
+      inhale (acc(($prj($t_block_label_expr_2, 0)).$int,write) && acc(
+                                                                   ($prj($t_block_label_expr_2,
+                                                                    1)).$int,write));
+      ($prj($t_block_label_expr_2, 0)).$int := 24;
+      ($prj($t_block_label_expr_2, 1)).$int := 24;
+      exhale acc(($prj($t_block_label_expr_2, 0)).$int,wildcard);
+      inhale acc(($prj($t_block_label_expr_2, 0)).$int,wildcard);
+      exhale acc(($prj($t_block_label_expr_2, 1)).$int,wildcard);
+      inhale acc(($prj($t_block_label_expr_2, 1)).$int,wildcard);
+      block_label_expr := $t_block_label_expr_2;
+      goto $lbl$block_2;
+      label $lbl$block_2;
+      assert ((($prj(block_label_expr, 0)).$int == 24) && (($prj(block_label_expr,
+                                                             1)).$int == 24));
+      v := 0;
+      if (true)
+         { 
+           v := 42;
+           goto $lbl$mutability; 
+         };
+      v := 100;
+      label $lbl$mutability;
+      assert (v == 42);
+      v := 0;
+      if (false)
+         { 
+           v := 42;
+           goto $lbl$mutability_2; 
+         };
+      v := 100;
+      label $lbl$mutability_2;
+      assert (v == 100);
+      label $Ret; 
+    }
+method loops($Self: Ref)
+    
+    requires $Perm($Self)
+    ensures $Perm($Self)
+    { var i: Int
+      i := 0;
+      while ((i < 5))
+         invariant (i < 3)
+         invariant ($Perm($Self) && $Inv($Self))
+         { 
+           label $lbl$continue$while_loop;
+           i := (i + 1);
+           if ((i == 3))
+              { 
+                goto $lbl$while_loop; 
+              };
+           goto $lbl$continue$while_loop;
+           i := 100; 
+         };
+      label $lbl$while_loop;
+      label $Ret; 
+    }

--- a/test/viper/ok/label-break-continue.vpr.stderr.ok
+++ b/test/viper/ok/label-break-continue.vpr.stderr.ok
@@ -1,0 +1,4 @@
+label-break-continue.mo:4.8-4.25: warning [M0194], unused identifier label_expressions (delete or rename to wildcard `_` or `_label_expressions`)
+label-break-continue.mo:24.9-24.18: warning [M0194], unused identifier mut_label (delete or rename to wildcard `_` or `_mut_label`)
+label-break-continue.mo:31.9-31.20: warning [M0194], unused identifier mut_label_2 (delete or rename to wildcard `_` or `_mut_label_2`)
+label-break-continue.mo:38.8-38.13: warning [M0194], unused identifier loops (delete or rename to wildcard `_` or `_loops`)


### PR DESCRIPTION
`break <label>` and `continue <label>` statements are parsed into the `BreakE` node, so, supporting breaks means that we support continues.

## `LabelE` as a Statement
The `LabelE` node could appear only next to the loops. `motoko`'s parser additionally wraps the loop's body with the label `continue <label_name>`. The final translation looks like this.

Motoko's pseudocode:
```
label while_loop while (cond) {
  ...
};
```

Parsed code:
```
(LabelE while_loop
  (WhileE cond (LabelE "continue while_loop" exp))
)
```

Translated code:
```
while (cond) {
 ...
 label $continue_while_loop
}
label $while_loop
```

`break`s in this case are translated into `goto`s.

## `LabelE` as an Assignment RHS
`let v = label lbl : <typ> <exp>` case is translated to
```
var $t_lbl: <typ>;
<tr_exp>;
label $lbl;
v := $t_lbl;
```
where `<tr_expr>` is the translated expression with one hack: the last declaration in the `BlockE` node is wrapped with `BreakE`. `break`s in this case are handled like `return`s:
```
break lbl(<exp>) => { $t_lbl := <exp>; goto $lbl; }
```