### PR TITLE
[DMS-40] Support numeric, boolean literals and wildcards in switch patterns

### DIFF
--- a/test/viper/lits.mo
+++ b/test/viper/lits.mo
@@ -1,0 +1,27 @@
+// @verify
+
+actor Lits {
+  func numLits() {
+    let i : Int = 42;
+    switch (i) {
+      case 42 {};
+      case 1000 {};
+      case _ {};
+    };
+
+    let n : Nat = 42;
+    switch (n) {
+      case (42 : Nat) {};
+      case 1000 {};
+      case _ {};
+    };
+  };
+
+  func boolLits() {
+    let b = false;
+    switch(b) {
+      case true {};
+      case false {};
+    };
+  }
+}

--- a/test/viper/ok/lits.silicon.ok
+++ b/test/viper/ok/lits.silicon.ok
@@ -1,0 +1,2 @@
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (lits.vpr@37.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (lits.vpr@38.1)

--- a/test/viper/ok/lits.tc.ok
+++ b/test/viper/ok/lits.tc.ok
@@ -1,0 +1,2 @@
+lits.mo:4.8-4.15: warning [M0194], unused identifier numLits (delete or rename to wildcard `_` or `_numLits`)
+lits.mo:20.8-20.16: warning [M0194], unused identifier boolLits (delete or rename to wildcard `_` or `_boolLits`)

--- a/test/viper/ok/lits.vpr.ok
+++ b/test/viper/ok/lits.vpr.ok
@@ -1,0 +1,106 @@
+/* BEGIN PRELUDE */
+/* Array encoding */
+domain Array {
+  function $loc(a: Array, i: Int): Ref
+  function $size(a: Array): Int
+  function $loc_inv1(r: Ref): Array
+  function $loc_inv2(r: Ref): Int
+  axiom $all_diff_array { forall a: Array, i: Int :: {$loc(a, i)} $loc_inv1($loc(a, i)) == a && $loc_inv2($loc(a, i)) == i }
+  axiom $size_nonneg { forall a: Array :: $size(a) >= 0 }
+}
+define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
+define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+/* Tuple encoding */
+domain Tuple {
+  function $prj(a: Tuple, i: Int): Ref
+  function $prj_inv1(r: Ref): Tuple
+  function $prj_inv2(r: Ref): Int
+  axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
+}
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
+/* Typed references */
+field $int: Int
+field $bool: Bool
+field $ref: Ref
+field $array: Array
+field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
+/* END PRELUDE */
+
+define $Perm($Self) (true)
+define $Inv($Self) (true)
+method __init__($Self: Ref)
+    
+    requires $Perm($Self)
+    ensures $Perm($Self)
+    ensures $Inv($Self)
+    { 
+       
+    }
+method numLits($Self: Ref)
+    
+    requires $Perm($Self)
+    ensures $Perm($Self)
+    { var i: Int
+      var n: Int
+      i := 42;
+      if ((i == 42))
+         { 
+            
+         }else
+         { 
+           if ((i == 1000))
+              { 
+                 
+              }else
+              { 
+                if (true)
+                   { 
+                      
+                   }; 
+              }; 
+         };
+      n := 42;
+      if ((n == 42))
+         { 
+            
+         }else
+         { 
+           if ((n == 1000))
+              { 
+                 
+              }else
+              { 
+                if (true)
+                   { 
+                      
+                   }; 
+              }; 
+         };
+      label $Ret; 
+    }
+method boolLits($Self: Ref)
+    
+    requires $Perm($Self)
+    ensures $Perm($Self)
+    { var b: Bool
+      b := false;
+      if ((b == true))
+         { 
+            
+         }else
+         { 
+           if ((b == false))
+              { 
+                 
+              }; 
+         };
+      label $Ret; 
+    }

--- a/test/viper/ok/lits.vpr.stderr.ok
+++ b/test/viper/ok/lits.vpr.stderr.ok
@@ -1,0 +1,2 @@
+lits.mo:4.8-4.15: warning [M0194], unused identifier numLits (delete or rename to wildcard `_` or `_numLits`)
+lits.mo:20.8-20.16: warning [M0194], unused identifier boolLits (delete or rename to wildcard `_` or `_boolLits`)


### PR DESCRIPTION
## Translations
Described literals and wildcard patterns in `switch` statements are translated in the next way:
* Wildcard pattern
```
case _ exp ==> if (true) exp
```
* Numeric/boolean literals
```
switch (n) {
  case 42 exp
}
==>
if (n == 42) exp
```
```
switch (n) {
  case true exp
}
==>
if (n == true) exp
```