### PR TITLE
[DMS-12] motoko-san: Let-bound variants

### DIFF
--- a/src/mo_frontend/typing.ml
+++ b/src/mo_frontend/typing.ml
@@ -1115,7 +1115,7 @@ and infer_exp' f env exp : T.typ =
   if not env.pre then begin
     assert (T.normalize t' <> T.Pre);
     let e = A.infer_effect_exp exp in
-    exp.note <- {note_typ = T.normalize t'; note_eff = e}
+    exp.note <- {note_typ = t'; note_eff = e}
   end;
   t'
 

--- a/src/mo_frontend/typing.mli
+++ b/src/mo_frontend/typing.mli
@@ -6,10 +6,10 @@ open Scope
 
 val initial_scope : scope
 
-val infer_prog : scope -> string option -> Async_cap.async_cap -> Syntax.prog -> (typ * scope) Diag.result
+val infer_prog : ?viper_mode:bool -> scope -> string option -> Async_cap.async_cap -> Syntax.prog -> (typ * scope) Diag.result
 
 val check_lib : scope -> string option -> Syntax.lib -> scope Diag.result
-val check_actors : scope -> Syntax.prog list -> unit Diag.result
+val check_actors : ?viper_mode:bool -> scope -> Syntax.prog list -> unit Diag.result
 val check_stab_sig : scope -> Syntax.stab_sig -> (field list) Diag.result
 
 val heartbeat_type : typ

--- a/src/pipeline/pipeline.ml
+++ b/src/pipeline/pipeline.ml
@@ -180,10 +180,10 @@ let async_cap_of_prog prog =
      else
        Async_cap.initial_cap()
 
-let infer_prog pkg_opt senv async_cap prog : (Type.typ * Scope.scope) Diag.result =
+let infer_prog ?(viper_mode=false) pkg_opt senv async_cap prog : (Type.typ * Scope.scope) Diag.result =
   let filename = prog.Source.note.Syntax.filename in
   phase "Checking" filename;
-  let r = Typing.infer_prog pkg_opt senv async_cap prog in
+  let r = Typing.infer_prog ~viper_mode pkg_opt senv async_cap prog in
   if !Flags.trace && !Flags.verbose then begin
     match r with
     | Ok ((_, scope), _) ->
@@ -198,15 +198,15 @@ let infer_prog pkg_opt senv async_cap prog : (Type.typ * Scope.scope) Diag.resul
   let* () = Definedness.check_prog prog in
   Diag.return t_sscope
 
-let rec check_progs senv progs : Scope.scope Diag.result =
+let rec check_progs ?(viper_mode=false) senv progs : Scope.scope Diag.result =
   match progs with
   | [] -> Diag.return senv
   | prog::progs' ->
     let open Diag.Syntax in
     let async_cap = async_cap_of_prog prog in
-    let* _t, sscope = infer_prog senv None async_cap prog in
+    let* _t, sscope = infer_prog ~viper_mode senv None async_cap prog in
     let senv' = Scope.adjoin senv sscope in
-    check_progs senv' progs'
+    check_progs ~viper_mode senv' progs'
 
 let check_lib senv pkg_opt lib : Scope.scope Diag.result =
   let filename = lib.Source.note.Syntax.filename in
@@ -417,14 +417,14 @@ let chase_imports parsefn senv0 imports : (Syntax.lib list * Scope.scope) Diag.r
   in
   Diag.map (fun () -> (List.rev !libs, !senv)) (go_set None imports)
 
-let load_progs parsefn files senv : load_result =
+let load_progs ?(viper_mode=false) parsefn files senv : load_result =
   let open Diag.Syntax in
   let* parsed = Diag.traverse (parsefn Source.no_region) files in
   let* rs = resolve_progs parsed in
   let progs' = List.map fst rs in
   let libs = List.concat_map snd rs in
   let* libs, senv' = chase_imports parsefn senv libs in
-  let* senv'' = check_progs senv' progs' in
+  let* senv'' = check_progs ~viper_mode senv' progs' in
   Diag.return (libs, progs', senv'')
 
 let load_decl parse_one senv : load_decl_result =
@@ -505,8 +505,8 @@ type viper_result = (string * (Source.region -> Source.region option)) Diag.resu
 
 let viper_files' parsefn files : viper_result =
   let open Diag.Syntax in
-  let* libs, progs, senv = load_progs parsefn files initial_stat_env in
-  let* () = Typing.check_actors senv progs in
+  let* libs, progs, senv = load_progs ~viper_mode:true parsefn files initial_stat_env in
+  let* () = Typing.check_actors ~viper_mode:true senv progs in
   let prog = CompUnit.combine_progs progs in
   let u = CompUnit.comp_unit_of_prog false prog in
   let* v = Viper.Trans.unit (Viper.Prep.prep_unit u) in

--- a/src/pipeline/pipeline.mli
+++ b/src/pipeline/pipeline.mli
@@ -38,4 +38,4 @@ val compile_files : Flags.compile_mode -> bool -> string list -> compile_result
 (* For use in the IDE server *)
 type load_result =
   (Syntax.lib list * Syntax.prog list * Scope.scope) Diag.result
-val load_progs : parse_fn -> string list -> Scope.scope -> load_result
+val load_progs : ?viper_mode:bool -> parse_fn -> string list -> Scope.scope -> load_result

--- a/test/viper/ok/variants.tc.ok
+++ b/test/viper/ok/variants.tc.ok
@@ -1,0 +1,1 @@
+variants.mo:12.16-12.21: warning [M0194], unused identifier getBW (delete or rename to wildcard `_` or `_getBW`)

--- a/test/viper/ok/variants.vpr.ok
+++ b/test/viper/ok/variants.vpr.ok
@@ -95,6 +95,16 @@ adt BW  { Black()
 adt Pair [A, B]
   { ordered(ordered$0 : A, ordered$1 : B)
     swapped(swapped$0 : Pair[B, A]) }
+method getBW($Self: Ref)
+     returns ($Res: BW)
+    requires $Perm($Self)
+    ensures $Perm($Self)
+    { var x: BW
+      x := Black();
+      $Res := x;
+      goto $Ret;
+      label $Ret; 
+    }
 method get($Self: Ref)
      returns ($Res: Pair[Int, BW])
     requires $Perm($Self)

--- a/test/viper/ok/variants.vpr.stderr.ok
+++ b/test/viper/ok/variants.vpr.stderr.ok
@@ -1,0 +1,1 @@
+variants.mo:12.16-12.21: warning [M0194], unused identifier getBW (delete or rename to wildcard `_` or `_getBW`)

--- a/test/viper/variants.mo
+++ b/test/viper/variants.mo
@@ -9,6 +9,11 @@ actor Variants {
     #swapped : Pair<B, A>;
   };
 
+  private func getBW(): BW {
+    let x : BW = #Black;
+    return x;
+  };
+
   func idPair<A, B>(p: Pair<A, B>) : Pair<A, B> {
     return p;
   };


### PR DESCRIPTION
This change fixes the Viper translation of let-bound variants by removing normalization from `infer_exp` in `typing.ml`, thus making the nominal type accessible in `trans.ml`

I don't know all the implications of such a change, maybe we should make the new behavior conditional on the `--viper` flag?