### PR TITLE
motoko-san: Fix a hang in reverse.mo

### DIFF
--- a/test/viper/ok/reverse.tc.ok
+++ b/test/viper/ok/reverse.tc.ok
@@ -1,3 +1,3 @@
-reverse.mo:22.13-22.23: warning [M0155], operator may trap for inferred type
+reverse.mo:26.13-26.23: warning [M0155], operator may trap for inferred type
   Nat
-reverse.mo:16.9-16.10: warning [M0194], unused identifier b (delete or rename to wildcard `_` or `_b`)
+reverse.mo:20.9-20.10: warning [M0194], unused identifier b (delete or rename to wildcard `_` or `_b`)

--- a/test/viper/ok/reverse.vpr.ok
+++ b/test/viper/ok/reverse.vpr.ok
@@ -102,8 +102,10 @@ method copy_xarray($Self: Ref)
     ensures $Perm($Self)
     ensures ($size($Res) == $size(($Self).xarray))
     ensures $array_acc($Res, $int, write)
-    { var t: Array
+    { var length: Int
+      var t: Array
       var i: Int
+      length := $size(($Self).xarray);
       inhale $array_acc(t, $int, write);
       inhale ($size(t) == 5);
       ($loc(t, 0)).$int := 0;
@@ -112,11 +114,14 @@ method copy_xarray($Self: Ref)
       ($loc(t, 3)).$int := 0;
       ($loc(t, 4)).$int := 0;
       i := 0;
-      while ((i < 5))
+      while ((i < length))
+         invariant (i >= 0)
          invariant $array_acc(t, $int, write)
          invariant ($Perm($Self) && $Inv($Self))
          { 
-           ($loc(t, i)).$int := ($loc(($Self).xarray, i)).$int; 
+           assert (i < length);
+           ($loc(t, i)).$int := ($loc(($Self).xarray, i)).$int;
+           i := (i + 1); 
          };
       $Res := t;
       goto $Ret;

--- a/test/viper/ok/reverse.vpr.stderr.ok
+++ b/test/viper/ok/reverse.vpr.stderr.ok
@@ -1,3 +1,3 @@
-reverse.mo:22.13-22.23: warning [M0155], operator may trap for inferred type
+reverse.mo:26.13-26.23: warning [M0155], operator may trap for inferred type
   Nat
-reverse.mo:16.9-16.10: warning [M0194], unused identifier b (delete or rename to wildcard `_` or `_b`)
+reverse.mo:20.9-20.10: warning [M0194], unused identifier b (delete or rename to wildcard `_` or `_b`)

--- a/test/viper/reverse.mo
+++ b/test/viper/reverse.mo
@@ -3,10 +3,14 @@ actor Reverse {
 
   private func copy_xarray(): [var Nat] {
     assert:return (var:return).size() == xarray.size();
+    let length = xarray.size();
     let t = [var 0, 0, 0, 0, 0];
     var i = 0;
-    while (i < 5) {
+    while (i < length) {
+        assert:loop:invariant (i >= 0);
+        assert:system (i < length);
         t[i] := xarray[i];
+        i := i + 1;
     };
     return t;
   };


### PR DESCRIPTION
* **Problem:** `await Reverse.reverse()` hangs (infinite loop)
* **Diagnosis:** `i` in copy_xarray wasn't being incremented
* **Solution:** add the increment, as well as assertions to ensure sufficient array access permissions