### PR TITLE
motoko-san: Stop using (==) in trans.ml and prep.ml

### DIFF
--- a/src/viper/prep.ml
+++ b/src/viper/prep.ml
@@ -33,7 +33,7 @@ let mono_calls_visitor (stk : mono_goal Stack.t) : visitor =
   { visit_exp = (function
     | {it = CallE({it = VarE v; at = v_at; note = v_note},inst,e); at; note} ->
         let goal = { mg_id = v.it; mg_typs = inst.note } in
-        let _ = (if goal.mg_typs == [] then () else Stack.push goal stk) in
+        let _ = (if goal.mg_typs = [] then () else Stack.push goal stk) in
         let s = string_of_mono_goal goal in
         {it = CallE({it = VarE (s @@ v_at); at=v_at; note=v_note},
                     {it = None; at=inst.at; note = []}, e); at; note}
@@ -87,7 +87,7 @@ let mk_template_dec_field (df : dec_field) : dec_field_template option =
                       at=fn_at;
                       note=fn_note},
                  None)) ->
-      if tp == [] then None else
+      if tp = [] then None else
       Some({dft_id = x;
             dft_mk = fun typs ->
               let env = init_subst_env tp typs in

--- a/src/viper/trans.ml
+++ b/src/viper/trans.ml
@@ -433,7 +433,7 @@ and dec ctxt d =
     add_locals ctxt (unwrap_tup_vars_pat p),
     fun ctxt' ->
       let conds, _, (ds, stmts) = pat_match ctxt' scrut p in
-      let irrefutable = (conds == []) in
+      let irrefutable = (conds = []) in
       if not irrefutable then failwith "impossible: tuple patterns must be irrefutable" else
       ds, stmts
   | M.(ExpD e) -> (* TODO: restrict to e of unit type? *)


### PR DESCRIPTION
Turns out that `==` in OCaml is physical (pointer) equality, and is not guaranteed to work as a test for an empty list.