### PR TITLE
[DMS-44] motoko-san: mock the Array module

### DIFF
--- a/src/viper/prelude.ml
+++ b/src/viper/prelude.ml
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/run.sh
+++ b/test/run.sh
@@ -314,6 +314,10 @@ do
     else
       TEST_MOC_ARGS=$EXTRA_MOC_ARGS
     fi
+    if [ $VIPER = 'yes' ]
+    then
+      TEST_MOC_ARGS="$TEST_MOC_ARGS --package base pkg/base"
+    fi
     moc_with_flags="env $moc_extra_env moc $moc_extra_flags $TEST_MOC_ARGS"
 
     # Typecheck

--- a/test/viper/ok/array.silicon.ok
+++ b/test/viper/ok/array.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (array.vpr@46.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (array.vpr@47.1)

--- a/test/viper/ok/array.vpr.ok
+++ b/test/viper/ok/array.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/ok/assertions.silicon.ok
+++ b/test/viper/ok/assertions.silicon.ok
@@ -1,2 +1,2 @@
-  [0] Postcondition of __init__ might not hold. Assertion $Self.u might not hold. (assertions.vpr@46.13--46.24)
-  [1] Assert might fail. Assertion $Self.u ==> $Self.v > 0 might not hold. (assertions.vpr@64.15--64.44)
+  [0] Postcondition of __init__ might not hold. Assertion $Self.u might not hold. (assertions.vpr@47.13--47.24)
+  [1] Assert might fail. Assertion $Self.u ==> $Self.v > 0 might not hold. (assertions.vpr@65.15--65.44)

--- a/test/viper/ok/assertions.vpr.ok
+++ b/test/viper/ok/assertions.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/ok/async.silicon.ok
+++ b/test/viper/ok/async.silicon.ok
@@ -1,1 +1,1 @@
-  [0] Exhale might fail. Assertion $Self.$message_async <= 1 might not hold. (async.vpr@69.15--69.42)
+  [0] Exhale might fail. Assertion $Self.$message_async <= 1 might not hold. (async.vpr@70.15--70.42)

--- a/test/viper/ok/async.vpr.ok
+++ b/test/viper/ok/async.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/ok/claim-broken.silicon.ok
+++ b/test/viper/ok/claim-broken.silicon.ok
@@ -1,1 +1,1 @@
-  [0] Exhale might fail. Assertion $Self.$message_async == 1 ==> $Self.claimed && $Self.count == 0 might not hold. (claim-broken.vpr@67.20--67.47)
+  [0] Exhale might fail. Assertion $Self.$message_async == 1 ==> $Self.claimed && $Self.count == 0 might not hold. (claim-broken.vpr@68.20--68.47)

--- a/test/viper/ok/claim-broken.vpr.ok
+++ b/test/viper/ok/claim-broken.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/ok/claim-reward-naive.vpr.ok
+++ b/test/viper/ok/claim-reward-naive.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/ok/claim-simple.silicon.ok
+++ b/test/viper/ok/claim-simple.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (claim-simple.vpr@38.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (claim-simple.vpr@39.1)

--- a/test/viper/ok/claim-simple.vpr.ok
+++ b/test/viper/ok/claim-simple.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/ok/claim.vpr.ok
+++ b/test/viper/ok/claim.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/ok/counter.silicon.ok
+++ b/test/viper/ok/counter.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (counter.vpr@38.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (counter.vpr@39.1)

--- a/test/viper/ok/counter.vpr.ok
+++ b/test/viper/ok/counter.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/ok/invariant.silicon.ok
+++ b/test/viper/ok/invariant.silicon.ok
@@ -1,1 +1,1 @@
-  [0] Postcondition of __init__ might not hold. Assertion $Self.count > 0 might not hold. (invariant.vpr@43.13--43.24)
+  [0] Postcondition of __init__ might not hold. Assertion $Self.count > 0 might not hold. (invariant.vpr@44.13--44.24)

--- a/test/viper/ok/invariant.vpr.ok
+++ b/test/viper/ok/invariant.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/ok/lits.silicon.ok
+++ b/test/viper/ok/lits.silicon.ok
@@ -1,2 +1,2 @@
-Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (lits.vpr@37.1)
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (lits.vpr@38.1)
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (lits.vpr@38.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (lits.vpr@39.1)

--- a/test/viper/ok/lits.vpr.ok
+++ b/test/viper/ok/lits.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/ok/loop-invariant.silicon.ok
+++ b/test/viper/ok/loop-invariant.silicon.ok
@@ -1,2 +1,2 @@
-Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (loop-invariant.vpr@37.1)
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (loop-invariant.vpr@38.1)
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (loop-invariant.vpr@38.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (loop-invariant.vpr@39.1)

--- a/test/viper/ok/loop-invariant.vpr.ok
+++ b/test/viper/ok/loop-invariant.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/ok/method-call.silicon.ok
+++ b/test/viper/ok/method-call.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (method-call.vpr@38.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (method-call.vpr@39.1)

--- a/test/viper/ok/method-call.vpr.ok
+++ b/test/viper/ok/method-call.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/ok/nats.silicon.ok
+++ b/test/viper/ok/nats.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (nats.vpr@38.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (nats.vpr@39.1)

--- a/test/viper/ok/nats.vpr.ok
+++ b/test/viper/ok/nats.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/ok/odd-even.silicon.ok
+++ b/test/viper/ok/odd-even.silicon.ok
@@ -1,2 +1,2 @@
-Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (odd-even.vpr@37.1)
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (odd-even.vpr@38.1)
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (odd-even.vpr@38.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (odd-even.vpr@39.1)

--- a/test/viper/ok/odd-even.vpr.ok
+++ b/test/viper/ok/odd-even.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/ok/option.silicon.ok
+++ b/test/viper/ok/option.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (option.vpr@38.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (option.vpr@39.1)

--- a/test/viper/ok/option.vpr.ok
+++ b/test/viper/ok/option.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/ok/polymono.silicon.ok
+++ b/test/viper/ok/polymono.silicon.ok
@@ -1,2 +1,2 @@
-Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (polymono.vpr@37.1)
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (polymono.vpr@38.1)
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (polymono.vpr@38.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (polymono.vpr@39.1)

--- a/test/viper/ok/polymono.vpr.ok
+++ b/test/viper/ok/polymono.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/ok/private.vpr.ok
+++ b/test/viper/ok/private.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/ok/reverse.silicon.ok
+++ b/test/viper/ok/reverse.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (reverse.vpr@41.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (reverse.vpr@42.1)

--- a/test/viper/ok/reverse.tc.ok
+++ b/test/viper/ok/reverse.tc.ok
@@ -1,7 +1,7 @@
-reverse.mo:31.13-31.23: warning [M0155], operator may trap for inferred type
+reverse.mo:32.13-32.23: warning [M0155], operator may trap for inferred type
   Nat
-reverse.mo:36.35-36.47: warning [M0155], operator may trap for inferred type
+reverse.mo:37.35-37.47: warning [M0155], operator may trap for inferred type
   Nat
-reverse.mo:36.35-36.51: warning [M0155], operator may trap for inferred type
+reverse.mo:37.35-37.51: warning [M0155], operator may trap for inferred type
   Nat
-reverse.mo:25.9-25.10: warning [M0194], unused identifier b (delete or rename to wildcard `_` or `_b`)
+reverse.mo:26.9-26.10: warning [M0194], unused identifier b (delete or rename to wildcard `_` or `_b`)

--- a/test/viper/ok/reverse.vpr.ok
+++ b/test/viper/ok/reverse.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref
@@ -115,13 +116,10 @@ method copy_xarray($Self: Ref)
       var t: Array
       var i: Int
       length := $size(($Self).xarray);
+      assert (length >= 0);
       inhale $array_acc(t, $int, write);
-      inhale ($size(t) == 5);
-      ($loc(t, 0)).$int := 0;
-      ($loc(t, 1)).$int := 0;
-      ($loc(t, 2)).$int := 0;
-      ($loc(t, 3)).$int := 0;
-      ($loc(t, 4)).$int := 0;
+      inhale ($size(t) == length);
+      inhale $array_init(t, $int, 0);
       i := 0;
       while ((i < length))
          invariant $array_acc(t, $int, write)

--- a/test/viper/ok/reverse.vpr.stderr.ok
+++ b/test/viper/ok/reverse.vpr.stderr.ok
@@ -1,7 +1,7 @@
-reverse.mo:31.13-31.23: warning [M0155], operator may trap for inferred type
+reverse.mo:32.13-32.23: warning [M0155], operator may trap for inferred type
   Nat
-reverse.mo:36.35-36.47: warning [M0155], operator may trap for inferred type
+reverse.mo:37.35-37.47: warning [M0155], operator may trap for inferred type
   Nat
-reverse.mo:36.35-36.51: warning [M0155], operator may trap for inferred type
+reverse.mo:37.35-37.51: warning [M0155], operator may trap for inferred type
   Nat
-reverse.mo:25.9-25.10: warning [M0194], unused identifier b (delete or rename to wildcard `_` or `_b`)
+reverse.mo:26.9-26.10: warning [M0194], unused identifier b (delete or rename to wildcard `_` or `_b`)

--- a/test/viper/ok/simple-funs.silicon.ok
+++ b/test/viper/ok/simple-funs.silicon.ok
@@ -1,2 +1,2 @@
-Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (simple-funs.vpr@37.1)
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (simple-funs.vpr@38.1)
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (simple-funs.vpr@38.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (simple-funs.vpr@39.1)

--- a/test/viper/ok/simple-funs.vpr.ok
+++ b/test/viper/ok/simple-funs.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/ok/tuple.silicon.ok
+++ b/test/viper/ok/tuple.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (tuple.vpr@42.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (tuple.vpr@43.1)

--- a/test/viper/ok/tuple.vpr.ok
+++ b/test/viper/ok/tuple.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/ok/variants.silicon.ok
+++ b/test/viper/ok/variants.silicon.ok
@@ -1,2 +1,2 @@
-Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (variants.vpr@37.1)
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (variants.vpr@38.1)
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (variants.vpr@38.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (variants.vpr@39.1)

--- a/test/viper/ok/variants.vpr.ok
+++ b/test/viper/ok/variants.vpr.ok
@@ -10,6 +10,7 @@ domain Array {
 }
 define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
 domain Tuple {
   function $prj(a: Tuple, i: Int): Ref

--- a/test/viper/pkg/base/Array.mo
+++ b/test/viper/pkg/base/Array.mo
@@ -1,0 +1,5 @@
+import Prim "mo:⛔";
+
+module {
+  public func init<X>(size : Nat, initValue : X) : [var X] = Prim.Array_init<X>(size, initValue);
+}

--- a/test/viper/reverse.mo
+++ b/test/viper/reverse.mo
@@ -1,3 +1,4 @@
+import Array "mo:base/Array";
 import Prim "mo:⛔";
 
 // @verify
@@ -7,7 +8,7 @@ actor Reverse {
   private func copy_xarray(): [var Nat] {
     assert:return (var:return).size() == xarray.size();
     let length = xarray.size();
-    let t = [var 0, 0, 0, 0, 0];
+    let t = Array.init<Nat>(length, 0);
     var i = 0;
     while (i < length) {
         assert:loop:invariant (i >= 0);


### PR DESCRIPTION
With this change, it is now possible to import the `mo:base/Array` module in `--viper` mode:

```
import Array "mo:base/Array";
```

The imported module does **not** undergo the Viper translation. Its definitions are type checked and brought into scope, but the usages are mocked in `trans.ml`. At the moment, only the `Array.init` operation is supported.

It is possible to add support for other modules by extending the `imported_module` type in `trans.ml` with new constructors.

The `reverse.mo` test case has been updated to make use of `Array.init`:

```diff
-    let t = [var 0, 0, 0, 0, 0];
+    let t = Array.init<Nat>(length, 0);
```

To run `moc` with access to the `base` package, supply the following command-line arguments: `--package base motoko-base/src` (using the actual path to your local clone of the [motoko-base](https://github.com/dfinity/motoko-base/) repository). For the sake of running tests, a tiny portion of the library is vendored in `test/viper/pkg/base`, so it is also possible to use `--package base test/viper/pkg/base` without cloning the motoko-base repository. The testsuite driver `test/run.sh` has been updated accordingly.