### PR TITLE
[DMS-23] Support forall and exists

### DIFF
--- a/src/prelude/prim.mo
+++ b/src/prelude/prim.mo
@@ -478,3 +478,13 @@ func regionStoreBlob(r : Region, offset : Nat64, val :  Blob) : () =
 let call_raw = @call_raw;
 
 func performanceCounter(counter : Nat32) : Nat64 = (prim "performanceCounter" : (Nat32) -> Nat64) counter;
+
+// predicates for motoko-san
+
+func forall<T>(f: T -> Bool): Bool {
+  (prim "forall" : <T>(T -> Bool) -> Bool) <T>(f);
+};
+
+func exists<T>(f: T -> Bool): Bool {
+  (prim "exists" : <T>(T -> Bool) -> Bool) <T>(f);
+};

--- a/src/viper/common.ml
+++ b/src/viper/common.ml
@@ -3,4 +3,3 @@ exception Unsupported of Source.region * string
 
 let unsupported at sexp =
   raise (Unsupported (at, (Wasm.Sexpr.to_string 80 sexp)))
-

--- a/src/viper/pretty.ml
+++ b/src/viper/pretty.ml
@@ -88,6 +88,9 @@ and pp_decl ppf decl =
     id.it
     pp_typ typ
 
+and pp_binder ppf (id, typ) =
+    fprintf ppf "@[%s : %a@]" id.it pp_typ typ
+
 and pp_pres ppf exps =
    fprintf ppf "@[<v 0>%a@]" (pp_print_list pp_pre) exps
 
@@ -166,6 +169,8 @@ and pp_exp ppf exp =
     fprintf ppf "@[old(%a)@]" pp_exp e
   | PermE p -> pp_perm ppf p
   | AccE (fldacc, perm) -> fprintf ppf "@[acc(%a,%a)@]" pp_fldacc fldacc pp_exp perm
+  | ForallE (binders, exp) -> fprintf ppf "@[forall %a :: %a@]" (pp_print_list ~pp_sep:comma pp_binder) binders pp_exp exp
+  | ExistsE (binders, exp) -> fprintf ppf "@[exists %a :: %a@]" (pp_print_list ~pp_sep:comma pp_binder) binders pp_exp exp
   | _ -> fprintf ppf "@[// pretty printer not implemented for node at %s@]" (string_of_region exp.at)
 
 and pp_perm ppf perm =

--- a/src/viper/syntax.ml
+++ b/src/viper/syntax.ml
@@ -55,6 +55,8 @@ and exp' =
   | AccE of fldacc * exp   (* acc((rcvr: exp).field, (exp: perm_amount)) *)
   | FldE of string               (* top-level field name, e.g. to be passed as a macro argument *)
   | CallE of string * exp list   (* macro or func call *)
+  | ForallE of (id * typ) list * exp
+  | ExistsE of (id * typ) list * exp
 
 and perm = (perm', info) Source.annotated_phrase
 
@@ -86,7 +88,7 @@ and stmt' =
   | WhileS of exp * invariants * seqn
   | LabelS of id
   | GotoS of id
-  (* TODO: these are temporary helper terms  that should not appear in the final translation 
+  (* TODO: these are temporary helper terms  that should not appear in the final translation
        we should avoid introducing them in the first place if possible, so they can be removed *)
   | PreconditionS of exp
   | PostconditionS of exp

--- a/test/fail/ok/no-timer-canc.tc.ok
+++ b/test/fail/ok/no-timer-canc.tc.ok
@@ -97,6 +97,7 @@ no-timer-canc.mo:3.10-3.21: type error [M0119], object field cancelTimer is not 
     error : Text -> Error;
     errorCode : Error -> ErrorCode;
     errorMessage : Error -> Text;
+    exists : <T>(T -> Bool) -> Bool;
     exp : Float -> Float;
     floatAbs : Float -> Float;
     floatCeil : Float -> Float;
@@ -111,6 +112,7 @@ no-timer-canc.mo:3.10-3.21: type error [M0119], object field cancelTimer is not 
     floatToInt64 : Float -> Int64;
     floatToText : Float -> Text;
     floatTrunc : Float -> Float;
+    forall : <T>(T -> Bool) -> Bool;
     getCertificate : () -> ?Blob;
     hashBlob : Blob -> Nat32;
     idlHash : Text -> Nat32;

--- a/test/fail/ok/no-timer-set.tc.ok
+++ b/test/fail/ok/no-timer-set.tc.ok
@@ -97,6 +97,7 @@ no-timer-set.mo:3.10-3.18: type error [M0119], object field setTimer is not cont
     error : Text -> Error;
     errorCode : Error -> ErrorCode;
     errorMessage : Error -> Text;
+    exists : <T>(T -> Bool) -> Bool;
     exp : Float -> Float;
     floatAbs : Float -> Float;
     floatCeil : Float -> Float;
@@ -111,6 +112,7 @@ no-timer-set.mo:3.10-3.18: type error [M0119], object field setTimer is not cont
     floatToInt64 : Float -> Int64;
     floatToText : Float -> Text;
     floatTrunc : Float -> Float;
+    forall : <T>(T -> Bool) -> Bool;
     getCertificate : () -> ?Blob;
     hashBlob : Blob -> Nat32;
     idlHash : Text -> Nat32;

--- a/test/viper/odd-even.mo
+++ b/test/viper/odd-even.mo
@@ -1,0 +1,16 @@
+import Prim "mo:⛔";
+
+// @verify
+actor OddEven {
+  func odd(n: Nat) : Nat {
+    assert:func (n % 2 == 1);
+    assert:system Prim.exists<Nat>(func (k : Nat) = 2 * k + 1 == n);
+    return n;
+  };
+
+  func even(n: Nat) : Nat {
+    assert:func (n % 2 == 0);
+    assert:system Prim.exists<Nat>(func (k : Nat) = 2 * k == n);
+    return n;
+  };
+}

--- a/test/viper/ok/odd-even.silicon.ok
+++ b/test/viper/ok/odd-even.silicon.ok
@@ -1,0 +1,2 @@
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (odd-even.vpr@37.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (odd-even.vpr@38.1)

--- a/test/viper/ok/odd-even.tc.ok
+++ b/test/viper/ok/odd-even.tc.ok
@@ -1,0 +1,2 @@
+odd-even.mo:5.8-5.11: warning [M0194], unused identifier odd (delete or rename to wildcard `_` or `_odd`)
+odd-even.mo:11.8-11.12: warning [M0194], unused identifier even (delete or rename to wildcard `_` or `_even`)

--- a/test/viper/ok/odd-even.vpr.ok
+++ b/test/viper/ok/odd-even.vpr.ok
@@ -1,0 +1,68 @@
+/* BEGIN PRELUDE */
+/* Array encoding */
+domain Array {
+  function $loc(a: Array, i: Int): Ref
+  function $size(a: Array): Int
+  function $loc_inv1(r: Ref): Array
+  function $loc_inv2(r: Ref): Int
+  axiom $all_diff_array { forall a: Array, i: Int :: {$loc(a, i)} $loc_inv1($loc(a, i)) == a && $loc_inv2($loc(a, i)) == i }
+  axiom $size_nonneg { forall a: Array :: $size(a) >= 0 }
+}
+define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(a, j).t, p)
+define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
+/* Tuple encoding */
+domain Tuple {
+  function $prj(a: Tuple, i: Int): Ref
+  function $prj_inv1(r: Ref): Tuple
+  function $prj_inv2(r: Ref): Int
+  axiom $all_diff_tuple { forall a: Tuple, i: Int :: {$prj(a, i)} $prj_inv1($prj(a, i)) == a && $prj_inv2($prj(a, i)) == i }
+}
+/* Option encoding */
+adt Option[T] {
+  None()
+  Some(some$0: T)
+}
+/* Typed references */
+field $int: Int
+field $bool: Bool
+field $ref: Ref
+field $array: Array
+field $tuple: Tuple
+field $option_int: Option[Int]
+field $option_bool: Option[Bool]
+field $option_array: Option[Array]
+field $option_tuple: Option[Tuple]
+/* END PRELUDE */
+
+define $Perm($Self) (true)
+define $Inv($Self) (true)
+method __init__($Self: Ref)
+    
+    requires $Perm($Self)
+    ensures $Perm($Self)
+    ensures $Inv($Self)
+    { 
+       
+    }
+method odd($Self: Ref, n: Int)
+     returns ($Res: Int)
+    requires $Perm($Self)
+    requires ((n % 2) == 1)
+    ensures $Perm($Self)
+    { 
+      assert exists k : Int :: (((2 * k) + 1) == n);
+      $Res := n;
+      goto $Ret;
+      label $Ret; 
+    }
+method even($Self: Ref, n: Int)
+     returns ($Res: Int)
+    requires $Perm($Self)
+    requires ((n % 2) == 0)
+    ensures $Perm($Self)
+    { 
+      assert exists k : Int :: ((2 * k) == n);
+      $Res := n;
+      goto $Ret;
+      label $Ret; 
+    }

--- a/test/viper/ok/odd-even.vpr.stderr.ok
+++ b/test/viper/ok/odd-even.vpr.stderr.ok
@@ -1,0 +1,2 @@
+odd-even.mo:5.8-5.11: warning [M0194], unused identifier odd (delete or rename to wildcard `_` or `_odd`)
+odd-even.mo:11.8-11.12: warning [M0194], unused identifier even (delete or rename to wildcard `_` or `_even`)

--- a/test/viper/ok/reverse.tc.ok
+++ b/test/viper/ok/reverse.tc.ok
@@ -1,3 +1,7 @@
-reverse.mo:26.13-26.23: warning [M0155], operator may trap for inferred type
+reverse.mo:31.13-31.23: warning [M0155], operator may trap for inferred type
   Nat
-reverse.mo:20.9-20.10: warning [M0194], unused identifier b (delete or rename to wildcard `_` or `_b`)
+reverse.mo:36.35-36.47: warning [M0155], operator may trap for inferred type
+  Nat
+reverse.mo:36.35-36.51: warning [M0155], operator may trap for inferred type
+  Nat
+reverse.mo:25.9-25.10: warning [M0194], unused identifier b (delete or rename to wildcard `_` or `_b`)

--- a/test/viper/ok/reverse.vpr.ok
+++ b/test/viper/ok/reverse.vpr.ok
@@ -60,7 +60,9 @@ method reverseArray$Nat($Self: Ref, a: Array)
     requires $array_acc(a, $int, write)
     ensures $Perm($Self)
     ensures $array_acc(a, $int, write)
-    ensures ($size(a) == $size(old(a)))
+    ensures ($size(a) == old($size(a)))
+    ensures forall k : Int :: (((0 <= k) && (k < $size(a))) ==> (($loc(a, k)).$int == 
+            old(($loc(a, (($size(a) - 1) - k))).$int)))
     { var b: Array
       var length: Int
       var i: Int
@@ -80,10 +82,17 @@ method reverseArray$Nat($Self: Ref, a: Array)
       i := (length - 1);
       j := 0;
       while ((i > j))
-         invariant ((i < length) && (i >= 0))
-         invariant ((j < length) && (j >= 0))
          invariant $array_acc(b, $int, wildcard)
          invariant $array_acc(a, $int, write)
+         invariant ((i < length) && (i >= 0))
+         invariant ((j < length) && (j >= 0))
+         invariant (i == (($size(a) - 1) - j))
+         invariant forall k : Int :: (((j <= k) && (k <= i)) ==> (($loc(a, k)).$int == 
+                   old(($loc(a, k)).$int)))
+         invariant forall k : Int :: (((0 <= k) && (k < j)) ==> (($loc(a, k)).$int == 
+                   old(($loc(a, (($size(a) - 1) - k))).$int)))
+         invariant forall k : Int :: (((i < k) && (k < $size(a))) ==> (
+                   ($loc(a, k)).$int == old(($loc(a, (($size(a) - 1) - k))).$int)))
          invariant ($Perm($Self) && $Inv($Self))
          { var tmp: Int
            tmp := ($loc(a, i)).$int;
@@ -115,8 +124,8 @@ method copy_xarray($Self: Ref)
       ($loc(t, 4)).$int := 0;
       i := 0;
       while ((i < length))
-         invariant (i >= 0)
          invariant $array_acc(t, $int, write)
+         invariant (i >= 0)
          invariant ($Perm($Self) && $Inv($Self))
          { 
            assert (i < length);

--- a/test/viper/ok/reverse.vpr.stderr.ok
+++ b/test/viper/ok/reverse.vpr.stderr.ok
@@ -1,3 +1,7 @@
-reverse.mo:26.13-26.23: warning [M0155], operator may trap for inferred type
+reverse.mo:31.13-31.23: warning [M0155], operator may trap for inferred type
   Nat
-reverse.mo:20.9-20.10: warning [M0194], unused identifier b (delete or rename to wildcard `_` or `_b`)
+reverse.mo:36.35-36.47: warning [M0155], operator may trap for inferred type
+  Nat
+reverse.mo:36.35-36.51: warning [M0155], operator may trap for inferred type
+  Nat
+reverse.mo:25.9-25.10: warning [M0194], unused identifier b (delete or rename to wildcard `_` or `_b`)

--- a/test/viper/reverse.mo
+++ b/test/viper/reverse.mo
@@ -1,3 +1,6 @@
+import Prim "mo:⛔";
+
+// @verify
 actor Reverse {
   var xarray : [var Nat] = [var 1, 2, 3, 4, 5];
 
@@ -16,7 +19,9 @@ actor Reverse {
   };
 
   private func reverseArray<T>(a : [var T]) : () {
-    assert:return a.size() == (old a).size();
+    assert:return a.size() == (old (a.size()));
+    assert:return Prim.forall<Nat>(
+      func (k : Nat) = (0 <= k and k < a.size()) implies a[k] == (old (a[a.size() - 1 - k])));
     let b = [1, 2, 4]; // space variable to test loop invariant deducing
     var length = a.size();
     if (length == 0) {
@@ -28,6 +33,13 @@ actor Reverse {
     while (i > j) {
       assert:loop:invariant (i < length and i >= 0);
       assert:loop:invariant (j < length and j >= 0);
+      assert:loop:invariant (i == a.size() - 1 - j);
+      assert:loop:invariant Prim.forall<Nat>(
+        func (k : Nat) = (j <= k and k <= i) implies a[k] == (old (a[k])));
+      assert:loop:invariant Prim.forall<Nat>(
+        func (k : Nat) = (0 <= k and k < j) implies a[k] == (old (a[a.size() - 1 - k])));
+      assert:loop:invariant Prim.forall<Nat>(
+        func (k : Nat) = (i < k and k < a.size()) implies a[k] == (old (a[a.size() - 1 - k])));
       var tmp = a[i];
       a[i] := a[j];
       a[j] := tmp;
@@ -36,7 +48,7 @@ actor Reverse {
     };
     return;
   };
-  
+
   public func reverse() : async () {
     var a = copy_xarray();
     reverseArray(a);


### PR DESCRIPTION
This PR adds two predicates for `motoko-san`: `forall` and `exists`. They could be used in assertions. Also, the `reverse.mo` example was updated.

## Translation
```
assert Prim.forall<Nat>(func i = (0 <= i and i <= a.size()) implies a[i] == (old (a[i])));
===>
assume forall i : Int :: (0 <= i && i <= size(a)) ==> loc(a, i).int == old(loc(a, i).int);
```
The same goes for `exists`.

## Limitations
In translation, we check for function calls with the next scheme:
```
SomeModule.forall<T>(func ...)
```
If the user uses their own `forall` function then the translation could be incorrect. 