### PR TITLE
[DMS-47] Support text type

### DIFF
--- a/src/viper/prelude.ml
+++ b/src/viper/prelude.ml
@@ -48,9 +48,13 @@ adt Option[T] {
   Some(some$0: T)
 }|prelude}
 
+let prelude_text_encoding : string = {prelude|/* Text encoding */
+function $concat(a: Int, b: Int): Int|prelude}
+
 let prelude_typed_references : string = {prelude|/* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]
@@ -64,6 +68,7 @@ let prelude reqs: string =
     prelude_array_encoding;
     prelude_tuple_encoding !(reqs.tuple_arities);
     prelude_option_encoding;
+    prelude_text_encoding;
     prelude_typed_references;
     "/* END PRELUDE */"
   ]

--- a/test/repl/ok/viper.stdout.ok
+++ b/test/repl/ok/viper.stdout.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/array.silicon.ok
+++ b/test/viper/ok/array.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (array.vpr@39.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (array.vpr@42.1)

--- a/test/viper/ok/array.vpr.ok
+++ b/test/viper/ok/array.vpr.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/assertions.silicon.ok
+++ b/test/viper/ok/assertions.silicon.ok
@@ -1,2 +1,2 @@
-  [0] Postcondition of __init__ might not hold. Assertion $Self.u might not hold. (assertions.vpr@39.13--39.24)
-  [1] Assert might fail. Assertion $Self.u ==> $Self.v > 0 might not hold. (assertions.vpr@57.15--57.44)
+  [0] Postcondition of __init__ might not hold. Assertion $Self.u might not hold. (assertions.vpr@42.13--42.24)
+  [1] Assert might fail. Assertion $Self.u ==> $Self.v > 0 might not hold. (assertions.vpr@60.15--60.44)

--- a/test/viper/ok/assertions.vpr.ok
+++ b/test/viper/ok/assertions.vpr.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/async.silicon.ok
+++ b/test/viper/ok/async.silicon.ok
@@ -1,1 +1,1 @@
-  [0] Exhale might fail. Assertion $Self.$message_async <= 1 might not hold. (async.vpr@62.15--62.42)
+  [0] Exhale might fail. Assertion $Self.$message_async <= 1 might not hold. (async.vpr@65.15--65.42)

--- a/test/viper/ok/async.vpr.ok
+++ b/test/viper/ok/async.vpr.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/claim-broken.silicon.ok
+++ b/test/viper/ok/claim-broken.silicon.ok
@@ -1,1 +1,1 @@
-  [0] Exhale might fail. Assertion $Self.$message_async == 1 ==> $Self.claimed && $Self.count == 0 might not hold. (claim-broken.vpr@60.20--60.47)
+  [0] Exhale might fail. Assertion $Self.$message_async == 1 ==> $Self.claimed && $Self.count == 0 might not hold. (claim-broken.vpr@63.20--63.47)

--- a/test/viper/ok/claim-broken.vpr.ok
+++ b/test/viper/ok/claim-broken.vpr.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/claim-reward-naive.vpr.ok
+++ b/test/viper/ok/claim-reward-naive.vpr.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/claim-simple.silicon.ok
+++ b/test/viper/ok/claim-simple.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (claim-simple.vpr@31.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (claim-simple.vpr@34.1)

--- a/test/viper/ok/claim-simple.vpr.ok
+++ b/test/viper/ok/claim-simple.vpr.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/claim.vpr.ok
+++ b/test/viper/ok/claim.vpr.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/counter.silicon.ok
+++ b/test/viper/ok/counter.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (counter.vpr@31.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (counter.vpr@34.1)

--- a/test/viper/ok/counter.vpr.ok
+++ b/test/viper/ok/counter.vpr.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/invariant.silicon.ok
+++ b/test/viper/ok/invariant.silicon.ok
@@ -1,1 +1,1 @@
-  [0] Postcondition of __init__ might not hold. Assertion $Self.count > 0 might not hold. (invariant.vpr@36.13--36.24)
+  [0] Postcondition of __init__ might not hold. Assertion $Self.count > 0 might not hold. (invariant.vpr@39.13--39.24)

--- a/test/viper/ok/invariant.vpr.ok
+++ b/test/viper/ok/invariant.vpr.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/label-break-continue.silicon.ok
+++ b/test/viper/ok/label-break-continue.silicon.ok
@@ -1,2 +1,2 @@
-Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (label-break-continue.vpr@32.1)
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (label-break-continue.vpr@33.1)
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (label-break-continue.vpr@35.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (label-break-continue.vpr@36.1)

--- a/test/viper/ok/label-break-continue.vpr.ok
+++ b/test/viper/ok/label-break-continue.vpr.ok
@@ -19,9 +19,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/lits.silicon.ok
+++ b/test/viper/ok/lits.silicon.ok
@@ -1,2 +1,2 @@
-Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (lits.vpr@30.1)
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (lits.vpr@31.1)
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (lits.vpr@33.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (lits.vpr@34.1)

--- a/test/viper/ok/lits.vpr.ok
+++ b/test/viper/ok/lits.vpr.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/loop-invariant.silicon.ok
+++ b/test/viper/ok/loop-invariant.silicon.ok
@@ -1,2 +1,2 @@
-Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (loop-invariant.vpr@30.1)
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (loop-invariant.vpr@31.1)
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (loop-invariant.vpr@33.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (loop-invariant.vpr@34.1)

--- a/test/viper/ok/loop-invariant.vpr.ok
+++ b/test/viper/ok/loop-invariant.vpr.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/method-call.silicon.ok
+++ b/test/viper/ok/method-call.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (method-call.vpr@31.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (method-call.vpr@34.1)

--- a/test/viper/ok/method-call.vpr.ok
+++ b/test/viper/ok/method-call.vpr.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/nats.silicon.ok
+++ b/test/viper/ok/nats.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (nats.vpr@31.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (nats.vpr@34.1)

--- a/test/viper/ok/nats.vpr.ok
+++ b/test/viper/ok/nats.vpr.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/odd-even.silicon.ok
+++ b/test/viper/ok/odd-even.silicon.ok
@@ -1,2 +1,2 @@
-Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (odd-even.vpr@30.1)
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (odd-even.vpr@31.1)
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (odd-even.vpr@33.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (odd-even.vpr@34.1)

--- a/test/viper/ok/odd-even.vpr.ok
+++ b/test/viper/ok/odd-even.vpr.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/option.silicon.ok
+++ b/test/viper/ok/option.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (option.vpr@31.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (option.vpr@34.1)

--- a/test/viper/ok/option.vpr.ok
+++ b/test/viper/ok/option.vpr.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/polymono.silicon.ok
+++ b/test/viper/ok/polymono.silicon.ok
@@ -1,2 +1,2 @@
-Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (polymono.vpr@30.1)
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (polymono.vpr@31.1)
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (polymono.vpr@33.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (polymono.vpr@34.1)

--- a/test/viper/ok/private.vpr.ok
+++ b/test/viper/ok/private.vpr.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/reverse.silicon.ok
+++ b/test/viper/ok/reverse.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (reverse.vpr@34.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (reverse.vpr@37.1)

--- a/test/viper/ok/reverse.vpr.ok
+++ b/test/viper/ok/reverse.vpr.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/simple-funs.silicon.ok
+++ b/test/viper/ok/simple-funs.silicon.ok
@@ -1,2 +1,2 @@
-Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (simple-funs.vpr@30.1)
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (simple-funs.vpr@31.1)
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (simple-funs.vpr@33.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (simple-funs.vpr@34.1)

--- a/test/viper/ok/simple-funs.vpr.ok
+++ b/test/viper/ok/simple-funs.vpr.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/text.silicon.ok
+++ b/test/viper/ok/text.silicon.ok
@@ -1,0 +1,1 @@
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (text.vpr@35.1)

--- a/test/viper/ok/text.tc.ok
+++ b/test/viper/ok/text.tc.ok
@@ -1,0 +1,8 @@
+text.mo:5.8-5.19: warning [M0194], unused identifier concat_text (delete or rename to wildcard `_` or `_concat_text`)
+text.mo:13.8-13.18: warning [M0194], unused identifier array_text (delete or rename to wildcard `_` or `_array_text`)
+text.mo:21.8-21.18: warning [M0194], unused identifier tuple_text (delete or rename to wildcard `_` or `_tuple_text`)
+text.mo:32.8-32.17: warning [M0194], unused identifier call_text (delete or rename to wildcard `_` or `_call_text`)
+text.mo:37.8-37.20: warning [M0194], unused identifier change_field (delete or rename to wildcard `_` or `_change_field`)
+text.mo:38.9-38.10: warning [M0194], unused identifier x (delete or rename to wildcard `_` or `_x`)
+text.mo:48.8-48.17: warning [M0194], unused identifier pass_text (delete or rename to wildcard `_` or `_pass_text`)
+text.mo:53.8-53.21: warning [M0194], unused identifier match_on_text (delete or rename to wildcard `_` or `_match_on_text`)

--- a/test/viper/ok/text.vpr.ok
+++ b/test/viper/ok/text.vpr.ok
@@ -12,6 +12,7 @@ define $array_acc(a, t, p) forall j: Int :: 0 <= j && j < $size(a) ==> acc($loc(
 define $array_untouched(a, t) forall j: Int :: 0 <= j && j < $size(a) ==> $loc(a, j).t == old($loc(a, j).t)
 define $array_init(a, t, x) forall i : Int :: 0 <= i && i < $size(a) ==> $loc(a, i).t == x
 /* Tuple encoding */
+adt Tuple$2 [T0, T1] { Tup$2(tup$2$0 : T0, tup$2$1 : T1) }
 /* Option encoding */
 adt Option[T] {
   None()
@@ -30,7 +31,7 @@ field $option_bool: Option[Bool]
 field $option_array: Option[Array]
 /* END PRELUDE */
 
-define $Perm($Self) (true)
+define $Perm($Self) (((true && acc(($Self).fld1,write)) && acc(($Self).fld2,write)))
 define $Inv($Self) (true)
 method __init__($Self: Ref)
     
@@ -38,109 +39,111 @@ method __init__($Self: Ref)
     ensures $Perm($Self)
     ensures $Inv($Self)
     { 
-       
+      ($Self).fld1 := 4;
+      ($Self).fld2 := 4; 
     }
-method recur$Bool($Self: Ref, a: Bool)
-     returns ($Res: Bool)
-    requires $Perm($Self)
-    ensures $Perm($Self)
-    { 
-      $Res := recur$Bool($Self, a);
-      goto $Ret;
-      label $Ret; 
-    }
-method mut_recur_b$Nat($Self: Ref, x: Int)
-     returns ($Res: Int)
-    requires $Perm($Self)
-    ensures $Perm($Self)
-    { 
-      $Res := mut_recur_a$Nat($Self, x);
-      goto $Ret;
-      label $Ret; 
-    }
-method mut_recur_a$Nat($Self: Ref, x: Int)
-     returns ($Res: Int)
-    requires $Perm($Self)
-    ensures $Perm($Self)
-    { 
-      $Res := mut_recur_b$Nat($Self, x);
-      goto $Ret;
-      label $Ret; 
-    }
-method ignoreValue$Bool($Self: Ref, _a: Bool)
+field fld1: Int
+field fld2: Int
+method concat_text($Self: Ref)
     
     requires $Perm($Self)
     ensures $Perm($Self)
-    { 
+    { var x: Int
+      var y: Int
+      var z: Int
+      x := 0;
+      y := 1;
+      z := $concat(x, y);
+      assert (z == $concat(0, 1));
       label $Ret; 
     }
-method id$Int($Self: Ref, a: Int)
-     returns ($Res: Int)
-    requires $Perm($Self)
-    ensures $Perm($Self)
-    { 
-      $Res := a;
-      goto $Ret;
-      label $Ret; 
-    }
-method id$Bool($Self: Ref, a: Bool)
-     returns ($Res: Bool)
-    requires $Perm($Self)
-    ensures $Perm($Self)
-    { 
-      $Res := a;
-      goto $Ret;
-      label $Ret; 
-    }
-method firstValue$Bool$Int($Self: Ref, a: Bool, _b: Int)
-     returns ($Res: Bool)
-    requires $Perm($Self)
-    ensures $Perm($Self)
-    { 
-      $Res := id$Bool($Self, a);
-      goto $Ret;
-      label $Ret; 
-    }
-method firstValue$Bool$Bool($Self: Ref, a: Bool, _b: Bool)
-     returns ($Res: Bool)
-    requires $Perm($Self)
-    ensures $Perm($Self)
-    { 
-      $Res := id$Bool($Self, a);
-      goto $Ret;
-      label $Ret; 
-    }
-method f($Self: Ref)
+method array_text($Self: Ref)
     
     requires $Perm($Self)
-    requires $Inv($Self)
     ensures $Perm($Self)
-    ensures $Inv($Self)
-    { var _x1: Bool
-      var _x2: Int
-      _x1 := recur$Bool($Self, true);
-      _x2 := mut_recur_a$Nat($Self, 5);
+    { var arr: Array
+      inhale $array_acc(arr, $text, write);
+      inhale ($size(arr) == 2);
+      ($loc(arr, 0)).$text := 2;
+      ($loc(arr, 1)).$text := 2;
+      ($loc(arr, 0)).$text := 0;
+      ($loc(arr, 1)).$text := 1;
+      assert ((($loc(arr, 0)).$text == 0) && (($loc(arr, 1)).$text == 1));
       label $Ret; 
     }
-method ifThenElse($Self: Ref, b: Bool, tru: Int, fls: Int)
+method tuple_text($Self: Ref)
+    
+    requires $Perm($Self)
+    ensures $Perm($Self)
+    { var tup: Tuple$2[Int, Int]
+      tup := Tup$2(0, 1);
+      assert (((tup).tup$2$0 == 0) && ((tup).tup$2$1 == 1));
+      label $Ret; 
+    }
+method get_text($Self: Ref)
      returns ($Res: Int)
     requires $Perm($Self)
-    requires $Inv($Self)
     ensures $Perm($Self)
-    ensures $Inv($Self)
-    { var c1: Bool
-      var c2: Bool
-      ignoreValue$Bool($Self, b);
-      c1 := id$Bool($Self, b);
-      c2 := id$Bool($Self, b);
-      c2 := firstValue$Bool$Int($Self, c2, tru);
-      c2 := firstValue$Bool$Bool($Self, c2, c2);
-      if ((c1 && c2))
+    ensures ($Res == 0)
+    { 
+      $Res := 0;
+      goto $Ret;
+      label $Ret; 
+    }
+method call_text($Self: Ref)
+    
+    requires $Perm($Self)
+    ensures $Perm($Self)
+    { var res: Int
+      res := get_text($Self);
+      assert (res == 0);
+      label $Ret; 
+    }
+method text_arg($Self: Ref, txt: Int)
+     returns ($Res: Int)
+    requires $Perm($Self)
+    requires (txt == 3)
+    ensures $Perm($Self)
+    ensures ($Res == $concat(3, 4))
+    { 
+      $Res := $concat(txt, 4);
+      goto $Ret;
+      label $Ret; 
+    }
+method pass_text($Self: Ref)
+    
+    requires $Perm($Self)
+    ensures $Perm($Self)
+    { var res: Int
+      res := text_arg($Self, 3);
+      assert (res == $concat(3, 4));
+      label $Ret; 
+    }
+method match_on_text($Self: Ref)
+     returns ($Res: Int)
+    requires $Perm($Self)
+    ensures $Perm($Self)
+    ensures ($Res == 42)
+    { var txt: Int
+      txt := get_text($Self);
+      if ((txt == 0))
          { 
-           $Res := id$Int($Self, tru);
+           $Res := 42;
            goto $Ret; 
+         }else
+         { 
+           if ((txt == 1))
+              { 
+                $Res := 100;
+                goto $Ret; 
+              }else
+              { 
+                if (true)
+                   { 
+                     $Res := 0;
+                     goto $Ret; 
+                   }; 
+              }; 
          };
-      $Res := id$Int($Self, fls);
-      goto $Ret;
       label $Ret; 
     }

--- a/test/viper/ok/text.vpr.stderr.ok
+++ b/test/viper/ok/text.vpr.stderr.ok
@@ -1,0 +1,8 @@
+text.mo:5.8-5.19: warning [M0194], unused identifier concat_text (delete or rename to wildcard `_` or `_concat_text`)
+text.mo:13.8-13.18: warning [M0194], unused identifier array_text (delete or rename to wildcard `_` or `_array_text`)
+text.mo:21.8-21.18: warning [M0194], unused identifier tuple_text (delete or rename to wildcard `_` or `_tuple_text`)
+text.mo:32.8-32.17: warning [M0194], unused identifier call_text (delete or rename to wildcard `_` or `_call_text`)
+text.mo:37.8-37.20: warning [M0194], unused identifier change_field (delete or rename to wildcard `_` or `_change_field`)
+text.mo:38.9-38.10: warning [M0194], unused identifier x (delete or rename to wildcard `_` or `_x`)
+text.mo:48.8-48.17: warning [M0194], unused identifier pass_text (delete or rename to wildcard `_` or `_pass_text`)
+text.mo:53.8-53.21: warning [M0194], unused identifier match_on_text (delete or rename to wildcard `_` or `_match_on_text`)

--- a/test/viper/ok/tuple.silicon.ok
+++ b/test/viper/ok/tuple.silicon.ok
@@ -1,1 +1,1 @@
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (tuple.vpr@36.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (tuple.vpr@39.1)

--- a/test/viper/ok/tuple.vpr.ok
+++ b/test/viper/ok/tuple.vpr.ok
@@ -22,9 +22,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/ok/unsupported.vpr.stderr.ok
+++ b/test/viper/ok/unsupported.vpr.stderr.ok
@@ -1,4 +1,4 @@
 unsupported.mo:5.7-5.8: warning [M0194], unused identifier x (delete or rename to wildcard `_` or `_x`)
-(unknown location): viper error [0], translation to viper failed:
-(Prim Text)
+unsupported.mo:5.17-5.20: viper error [0], translation to viper failed:
+(LitE (CharLit 97))
 

--- a/test/viper/ok/variants.silicon.ok
+++ b/test/viper/ok/variants.silicon.ok
@@ -1,2 +1,2 @@
-Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (variants.vpr@30.1)
-Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (variants.vpr@31.1)
+Parse warning: In macro $Perm, the following parameters were defined but not used: $Self  (variants.vpr@33.1)
+Parse warning: In macro $Inv, the following parameters were defined but not used: $Self  (variants.vpr@34.1)

--- a/test/viper/ok/variants.vpr.ok
+++ b/test/viper/ok/variants.vpr.ok
@@ -17,9 +17,12 @@ adt Option[T] {
   None()
   Some(some$0: T)
 }
+/* Text encoding */
+function $concat(a: Int, b: Int): Int
 /* Typed references */
 field $int: Int
 field $bool: Bool
+field $text: Int
 field $ref: Ref
 field $array: Array
 field $option_int: Option[Int]

--- a/test/viper/text.mo
+++ b/test/viper/text.mo
@@ -1,0 +1,63 @@
+actor Text {
+  let fld1 = "42";
+  var fld2 = "42";
+
+  func concat_text() {
+    let x = "foo";
+    let y = "bar";
+    let z = x # y;
+
+    assert:system z == "foo" # "bar";
+  };
+
+  func array_text() {
+    let arr: [var Text] = [var "", ""];
+    arr[0] := "foo";
+    arr[1] := "bar";
+
+    assert:system arr[0] == "foo" and arr[1] == "bar";
+  };
+
+  func tuple_text() {
+    let tup: (Text, Text) = ("foo", "bar");
+
+    assert:system tup.0 == "foo" and tup.1 == "bar";
+  };
+
+  func get_text(): Text {
+    assert:return (var:return) == "foo";
+    return "foo";
+  };
+
+  func call_text() {
+    let res = get_text();
+    assert:system res == "foo";
+  };
+
+  func change_field(): async () {
+    let x = fld1;
+    fld2 := "1000";
+  };
+
+  func text_arg(txt: Text): Text {
+    assert:func txt == "abc";
+    assert:return (var:return) == "abc" # "42";
+    return txt # "42";
+  };
+
+  func pass_text() {
+    let res = text_arg("abc");
+    assert:system res == "abc" # "42";
+  };
+
+  func match_on_text(): Int {
+    assert:return (var:return) == 42;
+
+    let txt = get_text();
+    switch txt {
+      case "foo" return 42;
+      case "bar" return 100;
+      case _ return 0;
+    }
+  };
+}

--- a/test/viper/unsupported.mo
+++ b/test/viper/unsupported.mo
@@ -2,6 +2,6 @@
 
 actor {
 
-  let x = ""; // strings aren't supported
+  let x: Char = 'a'; // chars aren't supported
 
 }


### PR DESCRIPTION
This PR adds support for text in `motoko-san`. This is done by adding a field for each string literal and mapping them to field access.
## Example
```
let x = "some_string";
```
## Translation
```
...
field $text: Int // was generated for "some_string"
...
define $Perm($Self) (true && .. && acc($Self.$text, write)) // string literal could be accessed in any scope of the program
...
var x: Int;
x := $Self.$text;
```