### PR TITLE
[DMS-56] Pass the correct context in dec_field'

### DIFF
--- a/test/viper/ok/reverse.tc.ok
+++ b/test/viper/ok/reverse.tc.ok
@@ -1,7 +1,7 @@
-reverse.mo:32.13-32.23: warning [M0155], operator may trap for inferred type
+reverse.mo:34.13-34.23: warning [M0155], operator may trap for inferred type
   Nat
-reverse.mo:37.35-37.47: warning [M0155], operator may trap for inferred type
+reverse.mo:39.35-39.47: warning [M0155], operator may trap for inferred type
   Nat
-reverse.mo:37.35-37.51: warning [M0155], operator may trap for inferred type
+reverse.mo:39.35-39.51: warning [M0155], operator may trap for inferred type
   Nat
-reverse.mo:26.9-26.10: warning [M0194], unused identifier b (delete or rename to wildcard `_` or `_b`)
+reverse.mo:28.9-28.10: warning [M0194], unused identifier b (delete or rename to wildcard `_` or `_b`)

--- a/test/viper/ok/reverse.vpr.ok
+++ b/test/viper/ok/reverse.vpr.ok
@@ -47,6 +47,7 @@ method reverseArray$Nat($Self: Ref, a: Array)
     
     requires $Perm($Self)
     requires $array_acc(a, $int, write)
+    requires ($size(($Self).xarray) == 5)
     ensures $Perm($Self)
     ensures $array_acc(a, $int, write)
     ensures ($size(a) == old($size(a)))

--- a/test/viper/ok/reverse.vpr.stderr.ok
+++ b/test/viper/ok/reverse.vpr.stderr.ok
@@ -1,7 +1,7 @@
-reverse.mo:32.13-32.23: warning [M0155], operator may trap for inferred type
+reverse.mo:34.13-34.23: warning [M0155], operator may trap for inferred type
   Nat
-reverse.mo:37.35-37.47: warning [M0155], operator may trap for inferred type
+reverse.mo:39.35-39.47: warning [M0155], operator may trap for inferred type
   Nat
-reverse.mo:37.35-37.51: warning [M0155], operator may trap for inferred type
+reverse.mo:39.35-39.51: warning [M0155], operator may trap for inferred type
   Nat
-reverse.mo:26.9-26.10: warning [M0194], unused identifier b (delete or rename to wildcard `_` or `_b`)
+reverse.mo:28.9-28.10: warning [M0194], unused identifier b (delete or rename to wildcard `_` or `_b`)

--- a/test/viper/reverse.mo
+++ b/test/viper/reverse.mo
@@ -20,6 +20,8 @@ actor Reverse {
   };
 
   private func reverseArray<T>(a : [var T]) : () {
+    assert:func xarray.size() == 5;
+
     assert:return a.size() == (old (a.size()));
     assert:return Prim.forall<Nat>(
       func (k : Nat) = (0 <= k and k < a.size()) implies a[k] == (old (a[a.size() - 1 - k])));


### PR DESCRIPTION
In `dec_field'` in some places, we're passing the wrong context (e.g. `ctxt` instead of `ctxt'`). In this PR `ctxt` variables with ticks got stripped, let's use shadowing to get rid of this inconsistency.