### PR TITLE
[DMS-60] Misc fixes

### DIFF
--- a/src/viper/pretty.ml
+++ b/src/viper/pretty.ml
@@ -93,13 +93,15 @@ and pp_pres ppf exps =
    fprintf ppf "@[<v 0>%a@]" (pp_print_list pp_pre) exps
 
 and pp_pre ppf exp =
-   fprintf ppf "@[<v 2>requires %a@]" pp_exp exp
+   marks := exp.at :: !marks;
+   fprintf ppf "\017@[<v 2>requires %a@]\019" pp_exp exp
 
 and pp_posts ppf exps =
    fprintf ppf "@[<v 0>%a@]" (pp_print_list pp_post) exps
 
 and pp_post ppf exp =
-   fprintf ppf "@[<v 2>ensures %a@]" pp_exp exp
+   marks := exp.at :: !marks;
+   fprintf ppf "\017@[<v 2>ensures %a@]\019" pp_exp exp
 
 and pp_local ppf (id, typ) =
   fprintf ppf "@[<2>%s: %a@]"

--- a/src/viper/trans.ml
+++ b/src/viper/trans.ml
@@ -407,8 +407,8 @@ and dec_field' ctxt d =
         in
         let stmts = stmt ctxt e in
         let _, stmts = extract_concurrency stmts in
-        let pres, stmts' = List.partition_map (function { it = PreconditionS exp; _ } -> Left exp | s -> Right s) (snd stmts.it) in
-        let posts, stmts' = List.partition_map (function { it = PostconditionS exp; _ } -> Left exp | s -> Right s) stmts' in
+        let pres, stmts' = List.partition_map (function { it = PreconditionS exp; at; _ } -> Left { exp with at } | s -> Right s) (snd stmts.it) in
+        let posts, stmts' = List.partition_map (function { it = PostconditionS exp; at; _ } -> Left { exp with at } | s -> Right s) stmts' in
         let arg_preds = local_access_preds ctxt in
         let ret_preds, ret = rets ctxt t_opt in
         let pres = arg_preds @ pres in
@@ -434,8 +434,8 @@ and dec_field' ctxt d =
         in
         let stmts = stmt ctxt e in
         let _, stmts = extract_concurrency stmts in
-        let pres, stmts' = List.partition_map (function { it = PreconditionS exp; _ } -> Left exp | s -> Right s) (snd stmts.it) in
-        let posts, stmts' = List.partition_map (function { it = PostconditionS exp; _ } -> Left exp | s -> Right s) stmts' in
+        let pres, stmts' = List.partition_map (function { it = PreconditionS exp; at; _ } -> Left { exp with at } | s -> Right s) (snd stmts.it) in
+        let posts, stmts' = List.partition_map (function { it = PostconditionS exp; at; _ } -> Left { exp with at } | s -> Right s) stmts' in
         let arg_preds = local_access_preds ctxt in
         let ret_preds, ret = rets ctxt t_opt in
         let pres = arg_preds @ pres in

--- a/src/viper/trans.ml
+++ b/src/viper/trans.ml
@@ -562,7 +562,7 @@ and compile_while
       let label, ctxt = loop_label ctxt label_id in
       let stmts = stmt ctxt body in
       let decls, stmts = stmts.it in
-      !!(decls, !!(LabelS label) :: stmts)
+      !!(decls, stmts @ [ !!(LabelS label) ])
     | None -> stmt ctxt body
   in
   !!([], [ !!(WhileS(pred, invs, body)) ])

--- a/test/viper/ok/array-of-tuples.vpr.ok
+++ b/test/viper/ok/array-of-tuples.vpr.ok
@@ -60,17 +60,17 @@ method set_nested_mut_arr($Self: Ref, arr: Array)
     
     requires $Perm($Self)
     requires $array_acc(arr, $option$tuple2$option$int$tuple2$bool$bool,
-             write)
+              write)
     ensures $Perm($Self)
     ensures $array_acc(arr, $option$tuple2$option$int$tuple2$bool$bool,
-            write)
+             write)
     ensures ((($size(arr) >= 2) && (($loc(arr, 0)).$option$tuple2$option$int$tuple2$bool$bool == 
-      old(($loc(arr, 0)).$option$tuple2$option$int$tuple2$bool$bool))) && (
-      ($loc(arr, 1)).$option$tuple2$option$int$tuple2$bool$bool == Some(
-                                                                   Tup$2(
-                                                                   Some(42),
-                                                                   Tup$2(true,
-                                                                   true)))))
+       old(($loc(arr, 0)).$option$tuple2$option$int$tuple2$bool$bool))) && (
+       ($loc(arr, 1)).$option$tuple2$option$int$tuple2$bool$bool == Some(
+                                                                    Tup$2(
+                                                                    Some(42),
+                                                                    Tup$2(true,
+                                                                    true)))))
     { 
       assume ($size(arr) >= 2);
       ($loc(arr, 1)).$option$tuple2$option$int$tuple2$bool$bool := Some(

--- a/test/viper/ok/label-break-continue.vpr.ok
+++ b/test/viper/ok/label-break-continue.vpr.ok
@@ -101,14 +101,14 @@ method loops($Self: Ref)
          invariant $Perm($Self)
          invariant (i < 3)
          { 
-           label $lbl$continue$while_loop;
            i := (i + 1);
            if ((i == 3))
               { 
                 goto $lbl$while_loop; 
               };
            goto $lbl$continue$while_loop;
-           i := 100; 
+           i := 100;
+           label $lbl$continue$while_loop; 
          };
       label $lbl$while_loop;
       label $Ret; 

--- a/test/viper/ok/reverse.vpr.ok
+++ b/test/viper/ok/reverse.vpr.ok
@@ -51,8 +51,9 @@ method reverseArray$Nat($Self: Ref, a: Array)
     ensures $array_acc(a, $int, write)
     ensures ($size(($Self).xarray) == 5)
     ensures ($size(a) == old($size(a)))
-    ensures (forall k : Int :: (((0 <= k) && (k < $size(a))) ==> (($loc(a, k)).$int == 
-            old(($loc(a, (($size(a) - 1) - k))).$int))))
+    ensures (forall k : Int :: (((0 <= k) && (k < $size(a))) ==> (($loc(a,
+                                                                    k)).$int == 
+             old(($loc(a, (($size(a) - 1) - k))).$int))))
     { var b: Array
       var length: Int
       var i: Int

--- a/test/viper/ok/todo_record.tc.ok
+++ b/test/viper/ok/todo_record.tc.ok
@@ -1,0 +1,2 @@
+todo_record.mo:109.23-109.28: warning [M0155], operator may trap for inferred type
+  Nat

--- a/test/viper/ok/todo_record.vpr.ok
+++ b/test/viper/ok/todo_record.vpr.ok
@@ -58,17 +58,17 @@ method resize($Self: Ref, n: Int)
     requires $Perm($Self)
     requires ((0 <= ($Self).num) && (($Self).num <= $size(($Self).todos)))
     requires (forall i : Int :: (((0 <= i) && (i < ($Self).num)) ==> (
-             (($loc(($Self).todos, i)).$c_ToDo).$ToDo$id < ($Self).nextId)))
+              (($loc(($Self).todos, i)).$c_ToDo).$ToDo$id < ($Self).nextId)))
     ensures $Perm($Self)
     ensures ((0 <= ($Self).num) && (($Self).num <= $size(($Self).todos)))
     ensures (forall i : Int :: (((0 <= i) && (i < ($Self).num)) ==> (
-            (($loc(($Self).todos, i)).$c_ToDo).$ToDo$id < ($Self).nextId)))
+             (($loc(($Self).todos, i)).$c_ToDo).$ToDo$id < ($Self).nextId)))
     ensures ((($Self).num == old(($Self).num)) && (($Self).nextId == 
-      old(($Self).nextId)))
+       old(($Self).nextId)))
     ensures ($size(($Self).todos) >= n)
     ensures (old($size(($Self).todos)) <= $size(($Self).todos))
     ensures (forall i : Int :: (((0 <= i) && (i < old($size(($Self).todos)))) ==> (
-            ($loc(($Self).todos, i)).$c_ToDo == old(($loc(($Self).todos, i)).$c_ToDo))))
+             ($loc(($Self).todos, i)).$c_ToDo == old(($loc(($Self).todos, i)).$c_ToDo))))
     { var new_array: Array
       var i: Int
       if ((n <= $size(($Self).todos)))
@@ -111,10 +111,10 @@ method getTodos($Self: Ref)
     ensures $Perm($Self)
     ensures $array_acc($Res, $c_ToDo, wildcard)
     ensures ((($Self).num == old(($Self).num)) && (($Self).nextId == 
-      old(($Self).nextId)))
+       old(($Self).nextId)))
     ensures ($size(($Self).todos) == old($size(($Self).todos)))
     ensures (forall i : Int :: (((0 <= i) && (i < old($size(($Self).todos)))) ==> (
-            ($loc(($Self).todos, i)).$c_ToDo == old(($loc(($Self).todos, i)).$c_ToDo))))
+             ($loc(($Self).todos, i)).$c_ToDo == old(($loc(($Self).todos, i)).$c_ToDo))))
     ensures $Inv($Self)
     { var new_array: Array
       inhale $array_acc(new_array, $c_ToDo, write);
@@ -132,26 +132,27 @@ method getTodo($Self: Ref, id: Int)
     requires $Inv($Self)
     ensures $Perm($Self)
     ensures ((($Self).num == old(($Self).num)) && (($Self).nextId == 
-      old(($Self).nextId)))
+       old(($Self).nextId)))
     ensures ($size(($Self).todos) == old($size(($Self).todos)))
     ensures (forall i : Int :: (((0 <= i) && (i < old($size(($Self).todos)))) ==> (
-            ($loc(($Self).todos, i)).$c_ToDo == old(($loc(($Self).todos, i)).$c_ToDo))))
+             ($loc(($Self).todos, i)).$c_ToDo == old(($loc(($Self).todos, i)).$c_ToDo))))
     ensures ((exists i : Int :: (((0 <= i) && (i < ($Self).num)) && (
-             (($loc(($Self).todos, i)).$c_ToDo).$ToDo$id == id))) ==> 
-      (exists i : Int :: (((0 <= i) && (i < ($Self).num)) && (Some(($loc(
-                                                                    ($Self).todos,
-                                                                    i)).$c_ToDo) == 
-      ($Res).tup$2$0))))
-    ensures ((($Res).tup$2$0 == None()) == (forall i : Int :: (((0 <= i) && (i < 
-                                           ($Self).num)) ==> ((($loc(
-                                                                ($Self).todos,
-                                                                i)).$c_ToDo).$ToDo$id != id))))
-    ensures ((($Res).tup$2$0 != None()) ==> ((0 <= ($Res).tup$2$1) && (
-      ($Res).tup$2$1 < $size(($Self).todos))))
-    ensures ((($Res).tup$2$0 != None()) ==> (($Res).tup$2$0 == Some((
+              (($loc(($Self).todos, i)).$c_ToDo).$ToDo$id == id))) ==> 
+       (exists i : Int :: (((0 <= i) && (i < ($Self).num)) && (Some((
                                                                     $loc(
                                                                     ($Self).todos,
-                                                                    ($Res).tup$2$1)).$c_ToDo)))
+                                                                    i)).$c_ToDo) == 
+       ($Res).tup$2$0))))
+    ensures ((($Res).tup$2$0 == None()) == (forall i : Int :: (((0 <= i) && (i < 
+                                            ($Self).num)) ==> ((($loc(
+                                                                 ($Self).todos,
+                                                                 i)).$c_ToDo).$ToDo$id != id))))
+    ensures ((($Res).tup$2$0 != None()) ==> ((0 <= ($Res).tup$2$1) && (
+       ($Res).tup$2$1 < $size(($Self).todos))))
+    ensures ((($Res).tup$2$0 != None()) ==> (($Res).tup$2$0 == Some(
+                                                                ($loc(
+                                                                 ($Self).todos,
+                                                                 ($Res).tup$2$1)).$c_ToDo)))
     ensures $Inv($Self)
     { var i: Int
       var res: Option[ToDo]
@@ -200,10 +201,10 @@ method addTodo($Self: Ref, description: Int)
     ensures (($Self).nextId == (old(($Self).nextId) + 1))
     ensures ($Res == old(($Self).nextId))
     ensures (($loc(($Self).todos, (($Self).num - 1))).$c_ToDo == $RecordCtor_ToDo(description,
-                                                                 $Res,
-                                                                 TODO()))
+                                                                  $Res,
+                                                                  TODO()))
     ensures (forall i : Int :: (((0 <= i) && (i < (($Self).num - 1))) ==> (
-            ($loc(($Self).todos, i)).$c_ToDo == old(($loc(($Self).todos, i)).$c_ToDo))))
+             ($loc(($Self).todos, i)).$c_ToDo == old(($loc(($Self).todos, i)).$c_ToDo))))
     ensures $Inv($Self)
     { var id: Int
       id := ($Self).nextId;
@@ -225,14 +226,14 @@ method completeTodo($Self: Ref, id: Int)
     requires $Inv($Self)
     ensures $Perm($Self)
     ensures ((($Self).num == old(($Self).num)) && (($Self).nextId == 
-      old(($Self).nextId)))
+       old(($Self).nextId)))
     ensures ($size(($Self).todos) == old($size(($Self).todos)))
     ensures (forall i : Int :: ((((0 <= i) && (i < ($Self).num)) && (
-            (($loc(($Self).todos, i)).$c_ToDo).$ToDo$id != id)) ==> (
-            ($loc(($Self).todos, i)).$c_ToDo == old(($loc(($Self).todos, i)).$c_ToDo))))
+             (($loc(($Self).todos, i)).$c_ToDo).$ToDo$id != id)) ==> (
+             ($loc(($Self).todos, i)).$c_ToDo == old(($loc(($Self).todos, i)).$c_ToDo))))
     ensures (forall i : Int :: ((((0 <= i) && (i < ($Self).num)) && (
-            (($loc(($Self).todos, i)).$c_ToDo).$ToDo$id == id)) ==> (
-            (($loc(($Self).todos, i)).$c_ToDo).$ToDo$state == DONE())))
+             (($loc(($Self).todos, i)).$c_ToDo).$ToDo$id == id)) ==> (
+             (($loc(($Self).todos, i)).$c_ToDo).$ToDo$state == DONE())))
     ensures $Inv($Self)
     { var i: Int
       i := 0;
@@ -280,10 +281,10 @@ method showTodos($Self: Ref)
     requires $Inv($Self)
     ensures $Perm($Self)
     ensures ((($Self).num == old(($Self).num)) && (($Self).nextId == 
-      old(($Self).nextId)))
+       old(($Self).nextId)))
     ensures ($size(($Self).todos) == old($size(($Self).todos)))
     ensures (forall i : Int :: (((0 <= i) && (i < ($Self).num)) ==> (
-            ($loc(($Self).todos, i)).$c_ToDo == old(($loc(($Self).todos, i)).$c_ToDo))))
+             ($loc(($Self).todos, i)).$c_ToDo == old(($loc(($Self).todos, i)).$c_ToDo))))
     ensures $Inv($Self)
     { var output: Int
       var i: Int
@@ -327,11 +328,11 @@ method clearstate($Self: Ref)
     ensures (($Self).nextId == old(($Self).nextId))
     ensures ($size(($Self).todos) == old($size(($Self).todos)))
     ensures (forall i : Int :: ((((0 <= i) && (i < old(($Self).num))) && (
-            old((($loc(($Self).todos, i)).$c_ToDo).$ToDo$state) == TODO())) ==> 
-            (exists k : Int :: (((0 <= k) && (k < $size(($Self).todos))) && (
-            ($loc(($Self).todos, k)).$c_ToDo == old(($loc(($Self).todos, i)).$c_ToDo))))))
+             old((($loc(($Self).todos, i)).$c_ToDo).$ToDo$state) == TODO())) ==> 
+             (exists k : Int :: (((0 <= k) && (k < $size(($Self).todos))) && (
+             ($loc(($Self).todos, k)).$c_ToDo == old(($loc(($Self).todos, i)).$c_ToDo))))))
     ensures (forall i : Int :: (((0 <= i) && (i < ($Self).num)) ==> (
-            (($loc(($Self).todos, i)).$c_ToDo).$ToDo$state == TODO())))
+             (($loc(($Self).todos, i)).$c_ToDo).$ToDo$state == TODO())))
     ensures $Inv($Self)
     { var new_array: Array
       var i: Int

--- a/test/viper/ok/todo_record.vpr.ok
+++ b/test/viper/ok/todo_record.vpr.ok
@@ -178,12 +178,12 @@ method getTodo($Self: Ref, id: Int)
          None()))
          invariant ((res != None()) ==> (res == Some(($loc(($Self).todos, i)).$c_ToDo)))
          { 
-           label $lbl$continue$l;
            if (((($loc(($Self).todos, i)).$c_ToDo).$ToDo$id == id))
               { 
                 res := Some(($loc(($Self).todos, i)).$c_ToDo);
                 goto $lbl$l; 
-              }; 
+              };
+           label $lbl$continue$l; 
          };
       label $lbl$l;
       $Res := Tup$2(res, i);

--- a/test/viper/ok/todo_record.vpr.stderr.ok
+++ b/test/viper/ok/todo_record.vpr.stderr.ok
@@ -1,0 +1,2 @@
+todo_record.mo:109.23-109.28: warning [M0155], operator may trap for inferred type
+  Nat

--- a/test/viper/ok/todo_tuple.vpr.ok
+++ b/test/viper/ok/todo_tuple.vpr.ok
@@ -160,12 +160,12 @@ method getTodo($Self: Ref, id: Int)
                     old(($loc(($Self).todos, ii)).$tuple3$int$int$c_State))))
          invariant ((0 <= i) && (i <= ($Self).num))
          { 
-           label $lbl$continue$l;
            if (((($loc(($Self).todos, i)).$tuple3$int$int$c_State).tup$3$0 == id))
               { 
                 res := Some(($loc(($Self).todos, i)).$tuple3$int$int$c_State);
                 goto $lbl$l; 
-              }; 
+              };
+           label $lbl$continue$l; 
          };
       label $lbl$l;
       $Res := res;

--- a/test/viper/ok/todo_tuple.vpr.ok
+++ b/test/viper/ok/todo_tuple.vpr.ok
@@ -56,14 +56,14 @@ method resize($Self: Ref, n: Int)
     ensures $Perm($Self)
     ensures ((0 <= ($Self).num) && (($Self).num <= $size(($Self).todos)))
     ensures ((($Self).num == old(($Self).num)) && (($Self).nextId == 
-      old(($Self).nextId)))
+       old(($Self).nextId)))
     ensures ($size(($Self).todos) >= n)
     ensures (old($size(($Self).todos)) <= $size(($Self).todos))
     ensures (forall i : Int :: (((0 <= i) && (i < old($size(($Self).todos)))) ==> (
-            ($loc(($Self).todos, i)).$tuple3$int$int$c_State == old((
-                                                                    $loc(
-                                                                    ($Self).todos,
-                                                                    i)).$tuple3$int$int$c_State))))
+             ($loc(($Self).todos, i)).$tuple3$int$int$c_State == old(
+                                                                 ($loc(
+                                                                  ($Self).todos,
+                                                                  i)).$tuple3$int$int$c_State))))
     { var new_array: Array
       var i: Int
       if ((n <= $size(($Self).todos)))
@@ -107,13 +107,13 @@ method getTodos($Self: Ref)
     ensures $Perm($Self)
     ensures $array_acc($Res, $tuple3$int$int$c_State, wildcard)
     ensures ((($Self).num == old(($Self).num)) && (($Self).nextId == 
-      old(($Self).nextId)))
+       old(($Self).nextId)))
     ensures ($size(($Self).todos) == old($size(($Self).todos)))
     ensures (forall i : Int :: (((0 <= i) && (i < old($size(($Self).todos)))) ==> (
-            ($loc(($Self).todos, i)).$tuple3$int$int$c_State == old((
-                                                                    $loc(
-                                                                    ($Self).todos,
-                                                                    i)).$tuple3$int$int$c_State))))
+             ($loc(($Self).todos, i)).$tuple3$int$int$c_State == old(
+                                                                 ($loc(
+                                                                  ($Self).todos,
+                                                                  i)).$tuple3$int$int$c_State))))
     ensures $Inv($Self)
     { var new_array: Array
       inhale $array_acc(new_array, $tuple3$int$int$c_State, write);
@@ -131,16 +131,17 @@ method getTodo($Self: Ref, id: Int)
     requires $Inv($Self)
     ensures $Perm($Self)
     ensures ((($Self).num == old(($Self).num)) && (($Self).nextId == 
-      old(($Self).nextId)))
+       old(($Self).nextId)))
     ensures ($size(($Self).todos) == old($size(($Self).todos)))
     ensures (forall i : Int :: (((0 <= i) && (i < old($size(($Self).todos)))) ==> (
-            ($loc(($Self).todos, i)).$tuple3$int$int$c_State == old((
-                                                                    $loc(
-                                                                    ($Self).todos,
-                                                                    i)).$tuple3$int$int$c_State))))
+             ($loc(($Self).todos, i)).$tuple3$int$int$c_State == old(
+                                                                 ($loc(
+                                                                  ($Self).todos,
+                                                                  i)).$tuple3$int$int$c_State))))
     ensures ((exists i : Int :: (((0 <= i) && (i < ($Self).num)) && (
-             (($loc(($Self).todos, i)).$tuple3$int$int$c_State).tup$3$0 == id))) ==> 
-      (exists i : Int :: (((0 <= i) && (i < ($Self).num)) && (Some(($loc(
+              (($loc(($Self).todos, i)).$tuple3$int$int$c_State).tup$3$0 == id))) ==> 
+       (exists i : Int :: (((0 <= i) && (i < ($Self).num)) && (Some((
+                                                                    $loc(
                                                                     ($Self).todos,
                                                                     i)).$tuple3$int$int$c_State) == $Res))))
     ensures $Inv($Self)
@@ -182,12 +183,12 @@ method addTodo($Self: Ref, description: Int)
     ensures (($Self).nextId == (old(($Self).nextId) + 1))
     ensures ($Res == old(($Self).nextId))
     ensures (($loc(($Self).todos, (($Self).num - 1))).$tuple3$int$int$c_State == 
-      Tup$3($Res, description, TODO()))
+       Tup$3($Res, description, TODO()))
     ensures (forall i : Int :: (((0 <= i) && ((i + 1) < ($Self).num)) ==> (
-            ($loc(($Self).todos, i)).$tuple3$int$int$c_State == old((
-                                                                    $loc(
-                                                                    ($Self).todos,
-                                                                    i)).$tuple3$int$int$c_State))))
+             ($loc(($Self).todos, i)).$tuple3$int$int$c_State == old(
+                                                                 ($loc(
+                                                                  ($Self).todos,
+                                                                  i)).$tuple3$int$int$c_State))))
     ensures $Inv($Self)
     { var id: Int
       id := ($Self).nextId;
@@ -209,18 +210,18 @@ method completeTodo($Self: Ref, id: Int)
     requires $Inv($Self)
     ensures $Perm($Self)
     ensures ((($Self).num == old(($Self).num)) && (($Self).nextId == 
-      old(($Self).nextId)))
+       old(($Self).nextId)))
     ensures ($size(($Self).todos) == old($size(($Self).todos)))
     ensures (forall i : Int :: ((((0 <= i) && (i < ($Self).num)) && (
-            (($loc(($Self).todos, i)).$tuple3$int$int$c_State).tup$3$0 != id)) ==> (
-            ($loc(($Self).todos, i)).$tuple3$int$int$c_State == old((
-                                                                    $loc(
-                                                                    ($Self).todos,
-                                                                    i)).$tuple3$int$int$c_State))))
+             (($loc(($Self).todos, i)).$tuple3$int$int$c_State).tup$3$0 != id)) ==> (
+             ($loc(($Self).todos, i)).$tuple3$int$int$c_State == old(
+                                                                 ($loc(
+                                                                  ($Self).todos,
+                                                                  i)).$tuple3$int$int$c_State))))
     ensures (forall i : Int :: ((((0 <= i) && (i < ($Self).num)) && (
-            (($loc(($Self).todos, i)).$tuple3$int$int$c_State).tup$3$0 == id)) ==> (
-            (($loc(($Self).todos, i)).$tuple3$int$int$c_State).tup$3$2 == 
-            DONE())))
+             (($loc(($Self).todos, i)).$tuple3$int$int$c_State).tup$3$0 == id)) ==> (
+             (($loc(($Self).todos, i)).$tuple3$int$int$c_State).tup$3$2 == 
+             DONE())))
     ensures $Inv($Self)
     { var i: Int
       i := 0;
@@ -266,13 +267,13 @@ method showTodos($Self: Ref)
     requires $Inv($Self)
     ensures $Perm($Self)
     ensures ((($Self).num == old(($Self).num)) && (($Self).nextId == 
-      old(($Self).nextId)))
+       old(($Self).nextId)))
     ensures ($size(($Self).todos) == old($size(($Self).todos)))
     ensures (forall i : Int :: (((0 <= i) && (i < ($Self).num)) ==> (
-            ($loc(($Self).todos, i)).$tuple3$int$int$c_State == old((
-                                                                    $loc(
-                                                                    ($Self).todos,
-                                                                    i)).$tuple3$int$int$c_State))))
+             ($loc(($Self).todos, i)).$tuple3$int$int$c_State == old(
+                                                                 ($loc(
+                                                                  ($Self).todos,
+                                                                  i)).$tuple3$int$int$c_State))))
     ensures $Inv($Self)
     { var output: Int
       var i: Int
@@ -314,14 +315,14 @@ method clearCompleted($Self: Ref)
     ensures (($Self).nextId == old(($Self).nextId))
     ensures ($size(($Self).todos) == old($size(($Self).todos)))
     ensures (forall i : Int :: ((((0 <= i) && (i < old(($Self).num))) && (
-            old((($loc(($Self).todos, i)).$tuple3$int$int$c_State).tup$3$2) == 
-            TODO())) ==> (exists k : Int :: (((0 <= k) && (k < $size(
-                                                               ($Self).todos))) && (
-                         ($loc(($Self).todos, k)).$tuple3$int$int$c_State == 
-                         old(($loc(($Self).todos, i)).$tuple3$int$int$c_State))))))
+             old((($loc(($Self).todos, i)).$tuple3$int$int$c_State).tup$3$2) == 
+             TODO())) ==> (exists k : Int :: (((0 <= k) && (k < $size(
+                                                                ($Self).todos))) && (
+                          ($loc(($Self).todos, k)).$tuple3$int$int$c_State == 
+                          old(($loc(($Self).todos, i)).$tuple3$int$int$c_State))))))
     ensures (forall i : Int :: (((0 <= i) && (i < ($Self).num)) ==> (
-            (($loc(($Self).todos, i)).$tuple3$int$int$c_State).tup$3$2 == 
-            TODO())))
+             (($loc(($Self).todos, i)).$tuple3$int$int$c_State).tup$3$2 == 
+             TODO())))
     ensures $Inv($Self)
     { var new_array: Array
       var i: Int


### PR DESCRIPTION
In this PR some miscellaneous fixes were applied:
* Fixed wrong `continue` translation in while loops.
* Added locations for pre/post conditions in the source mapper.

## `continue` in While Loops
Previously, we were adding `continue` labels at the beginning of the `while` loop. This is not the correct translation because after `goto` the loop iteration check is skipped.
```
while (cond) {
  label $lbl$continue$loop;
  ...
  if (cond1) {
    goto $lbl$continue$loop;
  }
}
```
After going into `if (cond1)` `cond` check is skipped.

It's fixed by moving the `continue` label to the end of the loop.
```
while (cond) {
  ...
  if (cond1) {
    goto $lbl$continue$loop;
  }
  ...
  label $lbl$continue$loop;
}
```

## Locations for Pre/Post Conditions
We were lack of pre/post conditions locations in the source mapper. If the assertion contains an error the whole method body would be highlighted.
### Before
![image](https://github.com/serokell/motoko/assets/56638292/f05545a4-81b3-4e8f-ae2b-788a995b7aec)

### After
![image](https://github.com/serokell/motoko/assets/56638292/7151380c-657a-40ae-ab2e-26c1a6d98242)

