### PR TITLE
[VSC-7] Implement a cache for typechecking

### DIFF
--- a/src/js/moc_js.ml
+++ b/src/js/moc_js.ml
@@ -36,4 +36,5 @@ let () =
       method parseMotoko s = js_parse_motoko s
       method parseMotokoTyped paths = js_parse_motoko_typed paths
       method printDeps file = print_deps file
+      method parseMotokoTypedLsp paths = js_parse_motoko_typed_lsp paths
      end);

--- a/src/lang_utils/graph.ml
+++ b/src/lang_utils/graph.ml
@@ -1,0 +1,140 @@
+(* Copyright 2019 contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. *)
+(* NOTE: This file was modified from [graph.ml] from the LSP server for the LIGO project. *)
+
+let ( <@ ) f g x = f (g x)
+
+module type S = sig
+  type vertex
+
+  type t
+  val empty : t
+  val mem : vertex -> t -> bool
+  val vertex : vertex -> t -> t
+  val vertices : vertex list -> t -> t
+  val edge : vertex -> vertex -> t -> t
+  val from_assoc : (vertex * vertex) list -> t -> t
+  val from_assocs : (vertex * vertex list) list -> t -> t
+  val to_assocs : t -> (vertex * vertex list) list
+  val to_vertices : t -> vertex list
+  val post : vertex -> t -> vertex list option
+  val reachable : vertex -> t -> t option
+  val transpose : t -> t
+  val overlay : t -> t -> t
+  val to_undirected : t -> t
+  val wcc : t -> t list
+  val pp : (Format.formatter -> vertex -> unit) -> Format.formatter -> t -> unit
+end
+
+module Make (Ord : Map.OrderedType) : S with type vertex = Ord.t = struct
+  module Node_map = Map.Make (Ord)
+  module Node_set = Set.Make (Ord)
+
+  type vertex = Ord.t
+  type t = Node_set.t Node_map.t
+
+  let empty = Node_map.empty
+
+  let vertex node =
+    Node_map.update node (function
+      | None -> Some Node_set.empty
+      | Some child -> Some child)
+
+  let vertices vs g = List.fold_left (Fun.flip vertex) g vs
+  let mem = Node_map.mem
+
+  let edge from to' =
+    Node_map.update
+      from
+      (function
+        | None -> Some (Node_set.singleton to')
+        | Some child -> Some (Node_set.add to' child))
+    <@ vertex to'
+
+  let from_assoc vs g = List.fold_left (fun g (v1, v2) -> edge v1 v2 g) g vs
+
+  let from_assocs edges g =
+    List.fold_left
+      (fun g (node, nodes) ->
+        List.fold_left (fun g v -> edge node v g) (vertex node g) nodes)
+      g
+      edges
+
+  let to_assocs =
+    List.map (fun (parent, children) ->
+      parent, List.of_seq (Node_set.to_seq children))
+    <@ List.of_seq
+    <@ Node_map.to_seq
+
+  let to_vertices = List.map fst <@ to_assocs
+  let post node =
+    Option.map (List.of_seq <@ Node_set.to_seq) <@ Node_map.find_opt node
+
+  (** Internal: exposed implementation of [reachable] that performs no check
+      that [node] is in [g], and returns the set of visited vertices, taking the
+      initial set of [vis]ited nodes and [acc]umulated reachability graph. *)
+  let rec reachable_impl (vis : Node_set.t) (acc : t) (node : vertex) (g : t)
+      : Node_set.t * t
+    =
+    if Node_set.mem node vis
+    then vis, acc
+    else
+      Node_set.fold
+        (fun child (vis, acc) ->
+          reachable_impl vis (edge node child acc) child g)
+        (Node_map.find node g)
+        (Node_set.add node vis, acc)
+
+  let reachable node g =
+    if mem node g
+    then Some (snd @@ reachable_impl Node_set.empty empty node g)
+    else None
+
+  let transpose =
+    Node_map.fold
+      (fun parent children acc ->
+        Node_set.fold (fun child acc -> edge child parent acc) children acc)
+      empty
+
+  let overlay = Node_map.union (fun _parent l r -> Some (Node_set.union l r))
+  let to_undirected g = overlay g (transpose g)
+
+  let wcc g =
+    let double_edge_g = to_undirected g in
+    snd
+    @@ Node_map.fold
+         (fun parent _children (vis, acc) ->
+           if Node_set.mem parent vis
+           then vis, acc
+           else
+             let vis, g' = reachable_impl vis empty parent double_edge_g in
+             let g' =
+               Node_map.mapi (fun parent _children -> Node_map.find parent g) g'
+             in
+             vis, g' :: acc)
+         g
+         (Node_set.empty, [])
+
+  let pp pp_node ppf =
+    let pp_list pp_elt ppf =
+      let rec go ppf = function
+        | [] -> ()
+        | [ hd ] -> Format.fprintf ppf "%a" pp_elt hd
+        | hd :: tl -> Format.fprintf ppf "%a; %a" pp_elt hd go tl
+      in
+      Format.fprintf ppf "[%a]" go
+    in
+    Node_map.iter (fun parent children ->
+      Format.fprintf
+        ppf
+        "* %a -> %a\n"
+        pp_node
+        parent
+        (pp_list pp_node)
+        (List.of_seq (Node_set.to_seq children)))
+end

--- a/src/lang_utils/graph.mli
+++ b/src/lang_utils/graph.mli
@@ -1,0 +1,67 @@
+(* Copyright 2019 contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. *)
+(* NOTE: This file was modified from [graph.ml] from the LSP server for the LIGO project. *)
+
+module Make (Ord : Map.OrderedType) : sig
+  (** The type of nodes in the graph. *)
+  type vertex = Ord.t
+
+  (** The abstract graph type. *)
+  type t
+
+  (** A graph with no nodes. *)
+  val empty : t
+
+  (** Check if the graph contains the given vertex. *)
+  val mem : vertex -> t -> bool
+
+  (** Add a node to the graph. *)
+  val vertex : vertex -> t -> t
+
+  (** Add various nodes to the graph. *)
+  val vertices : vertex list -> t -> t
+
+  (** Add an edge going from the first to the second node to the graph. *)
+  val edge : vertex -> vertex -> t -> t
+
+  (** Add various edges each going from the first to the second node to the
+      graph. *)
+  val from_assoc : (vertex * vertex) list -> t -> t
+
+  (** Add various edges each going from the first to every list of the second
+      nodes to the graph. *)
+  val from_assocs : (vertex * vertex list) list -> t -> t
+
+  (** Convert the graph to a list of nodes, each going from the first node to
+      the list of second nodes. *)
+  val to_assocs : t -> (vertex * vertex list) list
+
+  (** Extract the list of nodes of the graph. *)
+  val to_vertices : t -> vertex list
+
+  (** Extract every incident child of a node, if found in the graph. *)
+  val post : vertex -> t -> vertex list option
+
+  (** Extract the subgraph of every reachable node, if found in the graph. *)
+  val reachable : vertex -> t -> t option
+
+  (** Reverse all the edges of the input graph. *)
+  val transpose : t -> t
+
+  (** Overlay a graph on top of another, performing their union. *)
+  val overlay : t -> t -> t
+
+  (** Create a double-edged graph from the input. *)
+  val to_undirected : t -> t
+
+  (** Get the Weakly Connected Components of the input graph. *)
+  val wcc : t -> t list
+
+  (** Pretty-print the graph, given a way to pretty-print a node. *)
+  val pp : (Format.formatter -> vertex -> unit) -> Format.formatter -> t -> unit
+end

--- a/src/pipeline/pipeline.mli
+++ b/src/pipeline/pipeline.mli
@@ -35,7 +35,26 @@ type compile_result =
 
 val compile_files : Flags.compile_mode -> bool -> string list -> compile_result
 
-(* For use in the IDE server *)
+(* For use in the language server *)
 type load_result =
   (Syntax.lib list * Syntax.prog list * Scope.scope) Diag.result
 val load_progs : ?viper_mode:bool -> ?check_actors:bool -> parse_fn -> string list -> Scope.scope -> load_result
+
+module Rim_ord : sig
+  type t = Syntax.resolved_import Source.phrase
+
+  val compare : t -> t -> int
+end
+
+module Rim_map : module type of Map.Make (Rim_ord)
+
+type lsp_load_result = (Syntax.prog list * Scope.t Rim_map.t) Diag.result
+
+val lsp_load
+  :  ?viper_mode:bool
+  -> ?check_actors:bool
+  -> parse_fn
+  -> string list
+  -> Scope.t
+  -> Scope.t Rim_map.t
+  -> lsp_load_result


### PR DESCRIPTION
Problem: When the language server loads a file, it goes through the process of typechecking all of its dependencies. We can be smarter about it and only load typecheck files that were invalidated.

Solution: Add `lsp_load` that uses a cache to avoid doing excessive typechecking work. Change `chase_imports` (renamed to `chase_imports_cached`) to build a dependency graph and use the cache on valid files. Recreate `chase_imports` to use `chase_imports_cached` but ignoring the cache. Expose these changes as `parseMotokoTypedLsp`.