### PR TITLE
[VSC-7] Fix dependency analysis

### DIFF
--- a/src/js/common.ml
+++ b/src/js/common.ml
@@ -157,14 +157,14 @@ let js_parse_motoko s =
     end)
     in Js.some (js_of_sexpr (Arrange.prog prog)))
 
-let js_parse_motoko_with_deps s =
-  let main_file = "" in
+let js_parse_motoko_with_deps main_file s =
+  let main_file = Js.to_string main_file in
   let s = Js.to_string s in
   let prog_and_deps_result =
     let open Diag.Syntax in
     let* prog, _ = Pipeline.parse_string main_file s in
     let* deps =
-      Pipeline.ResolveImport.resolve (Pipeline.resolve_flags ()) prog s
+      Pipeline.ResolveImport.resolve (Pipeline.resolve_flags ()) prog main_file
     in
     Diag.return (prog, deps)
   in

--- a/src/js/moc_js.ml
+++ b/src/js/moc_js.ml
@@ -34,7 +34,7 @@ let () =
       method compileWasm mode s = Flags.compiled := true; js_compile_wasm mode s
       method parseCandid s = js_parse_candid s
       method parseMotoko s = js_parse_motoko s
-      method parseMotokoWithDeps s = js_parse_motoko_with_deps s
+      method parseMotokoWithDeps path s = js_parse_motoko_with_deps path s
       method parseMotokoTyped paths scopeCache = js_parse_motoko_typed paths scopeCache
       method printDeps file = print_deps file
      end);


### PR DESCRIPTION
Problem: We need to pass the filename to the import resolver, which requires passing the filename to `parseMotokoWithDeps`.

Solution: Accept the file name and pass it to `resolve`.