### PR TITLE
test: `parseMotokoTyped()` for Serokell Milestone 1

### DIFF
--- a/test/test-moc.js
+++ b/test/test-moc.js
@@ -143,24 +143,33 @@ assert.deepStrictEqual(Motoko.check("bad.mo"), {
   code: null,
 });
 
-const astString = JSON.stringify(
-  Motoko.parseMotoko(Motoko.readFile("ast.mo"))
-);
-
 // Run interpreter
 assert.deepStrictEqual(Motoko.run([], "actor.mo"), {
-  stdout: "`ys6dh-5cjiq-5dc` : actor {main : shared query () -> async A__9<Text>}\n",
+  stdout:
+    "`ys6dh-5cjiq-5dc` : actor {main : shared query () -> async A__9<Text>}\n",
   stderr: "",
   result: { error: null },
 });
 
-// Check doc comments
-assert.match(astString, /"name":"\*","args":\["Program comment\\n      multi-line"/);
-assert.match(astString, /"name":"\*","args":\["Type comment"/);
-assert.match(astString, /"name":"\*","args":\["Variable comment"/);
-assert.match(astString, /"name":"\*","args":\["Function comment"/);
-assert.match(astString, /"name":"\*","args":\["Sub-module comment"/);
-assert.match(astString, /"name":"\*","args":\["Class comment"/);
+// Check AST format
+const astFile = Motoko.readFile("ast.mo");
+for (const ast of [
+  Motoko.parseMotoko(astFile),
+  Motoko.parseMotokoTyped(astFile, new Map())[0].ast,
+]) {
+  const astString = JSON.stringify(ast);
+
+  // Check doc comments
+  assert.match(
+    astString,
+    /"name":"\*","args":\["Program comment\\n      multi-line"/
+  );
+  assert.match(astString, /"name":"\*","args":\["Type comment"/);
+  assert.match(astString, /"name":"\*","args":\["Variable comment"/);
+  assert.match(astString, /"name":"\*","args":\["Function comment"/);
+  assert.match(astString, /"name":"\*","args":\["Sub-module comment"/);
+  assert.match(astString, /"name":"\*","args":\["Class comment"/);
+}
 
 // Check that long text literals type-check without error
 assert.deepStrictEqual(Motoko.check("text.mo"), {
@@ -168,7 +177,9 @@ assert.deepStrictEqual(Motoko.check("text.mo"), {
   diagnostics: [],
 });
 
-const candid = `
+// Check Candid format
+const candid =
+  `
 type T = nat;
 /// Program comment
 ///       multi-line
@@ -176,42 +187,44 @@ service : {
   /// Function comment
   main: () -> (T) query;
 }
-`.trim() + '\n';
-assert.deepStrictEqual(Motoko.candid('ast.mo'), {
+`.trim() + "\n";
+assert.deepStrictEqual(Motoko.candid("ast.mo"), {
   diagnostics: [
     {
-      category: 'type',
-      code: 'M0194',
-      message: 'unused identifier Prim (delete or rename to wildcard `_` or `_Prim`)',
+      category: "type",
+      code: "M0194",
+      message:
+        "unused identifier Prim (delete or rename to wildcard `_` or `_Prim`)",
       range: {
         end: {
           character: 13,
-          line: 3
+          line: 3,
         },
         start: {
           character: 9,
-          line: 3
-        }
+          line: 3,
+        },
       },
       severity: 2,
-      source: 'ast.mo'
+      source: "ast.mo",
     },
     {
-      category: 'type',
-      code: 'M0194',
-      message: 'unused identifier M (delete or rename to wildcard `_` or `_M`)',
+      category: "type",
+      code: "M0194",
+      message: "unused identifier M (delete or rename to wildcard `_` or `_M`)",
       range: {
         end: {
           character: 12,
-          line: 13
+          line: 13,
         },
         start: {
           character: 11,
-          line: 13
-        }
+          line: 13,
+        },
       },
       severity: 2,
-      source: 'ast.mo'
-    }
-  ], code: candid
+      source: "ast.mo",
+    },
+  ],
+  code: candid,
 });


### PR DESCRIPTION
Adds basic test coverage for `parseMotokoTyped()` in `moc.js` for #4931.
