### PR TITLE
[VSC-10] Address latest points from review

### DIFF
--- a/src/mo_def/arrange.ml
+++ b/src/mo_def/arrange.ml
@@ -87,15 +87,9 @@ module Make (Cfg : Config) = struct
      [typ] of a node but also its [Arrange_type.typ] (which motivated these
      changes). Arranging the type for every node would be expensive; there
      would be considerable duplication as there is no sharing mechanism
-     currently. As a compromise, we currently annotate only the nodes that
-     currently matter for the language server, i.e. [DotE] nodes and the left
-     expression of a [DotE] node (the latter is handled in [exp]). *)
-  let should_arrange_exp_typ ?arrange_typ e =
-    match e.it with
-    | DotE _ -> true
-    | _ -> Option.value ~default:false arrange_typ
-
-  let rec exp ?arrange_typ e = source e.at (annot ~arrange_typ:(should_arrange_exp_typ ?arrange_typ e) e.note (match e.it with
+     currently. As a compromise, we annotate only the nodes that currently
+     matter for the language server, i.e. the left expression of a [DotE] node. *)
+  let rec exp ?(arrange_typ = false) e = source e.at (annot ~arrange_typ e.note (match e.it with
     | VarE x              -> "VarE"      $$ [id x]
     | LitE l              -> "LitE"      $$ [lit !l]
     | ActorUrlE e         -> "ActorUrlE" $$ [exp e]

--- a/src/pipeline/test_field_srcs.ml
+++ b/src/pipeline/test_field_srcs.ml
@@ -154,7 +154,9 @@ let%expect_test "" =
       (@@ test-field-srcs.mo (Pos 9 16) (Pos 9 20))
     )
     Sources table:
+    test-field-srcs.mo:2.9-2.15: test-field-srcs.mo:2.9-2.15
     test-field-srcs.mo:3.17-3.21: test-field-srcs.mo:3.17-3.21
+    test-field-srcs.mo:8.9-8.15: test-field-srcs.mo:8.9-8.15
     test-field-srcs.mo:9.17-9.21: test-field-srcs.mo:3.17-3.21 test-field-srcs.mo:9.17-9.21
     test-field-srcs.mo:14.15-14.19: test-field-srcs.mo:14.15-14.19 |}]
 


### PR DESCRIPTION
Problem: We forgot to add sources for private fields. Also, turns out we don't need to serialize the type for DotE, only its left side.

Solution: In `object_of_scope`, also iterate private fields and add their sources. In `Arrange`, do not serialize the type for `DotE` nodes.